### PR TITLE
[php] support ingress.port

### DIFF
--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "php.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPort := .Values.ingress.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -33,6 +34,6 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: {{ $ingressPort }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
```
backend:
  servicePort: [[ IS PORT NUMBER ONLY ]]
```

Service names can not be transferred, so support port numbers.