### PR TITLE
fixes ci:diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,9 @@ jobs:
       - checkout
       - run: make ci:enable:k8s
       - run: make ci:enable:helm
-      - run: make apply
-      - run: make test
+      - run: make ci:diff
+      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make apply || exit 255"
+      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255"
   publish:
     machine: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: apply
 apply:
-	@ls -d */ | xargs -I{} /bin/bash -c "cd ./{} && make apply";
+	@ls -d */ | xargs -I{} /bin/bash -c "cd ./{} && make apply || exit 255";
 
 .PHONY: test
 test:
-	@ls -d */ | xargs -I{} /bin/bash -c "cd ./{} && make test";
+	@ls -d */ | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255";
 
 .PHONY: ci\:enable\:k8s
 ci\:enable\:k8s:
@@ -24,16 +24,34 @@ ci\:enable\:helm:
 	fi
 	echo 'export PATH=$$PWD:$$PATH' >> $${BASH_ENV:-"/home/circleci/.bashrc"};
 
+.PHONY: ci\:diff\:from
+ci\:diff\:from:
+	@branch=$$(git symbolic-ref --short HEAD); \
+		if [ "$${branch}" = "master" ]; then \
+			git --no-pager log --merges -n 2 --pretty=format:"%H" | tail -n 1; \
+		else \
+			echo "HEAD"; \
+		fi
+
+.PHONY: ci\:diff\:to
+ci\:diff\:to:
+	@branch=$$(git symbolic-ref --short HEAD); \
+		if [ "$${branch}" = "master" ]; then \
+			echo "HEAD"; \
+		else \
+			echo "master"; \
+		fi
+
 .PHONY: ci\:diff
 ci\:diff:
-	@git diff --name-only $$(echo $$CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g') | xargs -I{} dirname {} | sed 's/[.\/].*$$//' | sed '/^$$/d' | uniq;
+	@git diff --name-only "$$(make ci:diff:from)" "$$(make ci:diff:to)" | sed 's:^.*/compare/::g' | xargs -I{} dirname {} | sed 's/[.\/].*$$//' | sed '/^$$/d' | uniq;
 
 .PHONY: ci\:changelog
 ci\:changelog:
 	@if [ -n "${DIR}" ]; then \
-		git log --no-merges --pretty=format:"- %s" $$(echo $$CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g') -- ${DIR}; \
+		git --no-pager log --no-merges --pretty=format:"- %s" "$$(make ci:diff:from)...$$(make ci:diff:to)" -- ${DIR}; \
 	else \
-		git log --no-merges --pretty=format:"- %s" $$(echo $$CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g'); \
+		git --no-pager log --no-merges --pretty=format:"- %s" "$$(make ci:diff:from)...$$(make ci:diff:to)"; \
 	fi
 
 .PHONY: ci\:notify


### PR DESCRIPTION
There was a problem that `CIRCLE_COMPARE_URL` saw only the difference from the last build.
So changed it as follows.

* `master` branch will see the difference to the previous merge.
* `PR` branch will see the difference with `master` branch.
* Builds and tests only perform differences

## Reference URL

https://github.com/chatwork/dockerfiles/pull/22