### PR TITLE
fixes ci:diff && push gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run: make ci:enable:helm
       - run: make ci:diff
       - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make apply || exit 255"
-      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255" || make ci:dump && exit 1
+      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255" || (make ci:dump && exit 1)
   publish:
     machine: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ apply:
 
 .PHONY: test
 test:
-	@ls -d */ | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255" || make ci:dump && exit 1;
+	@ls -d */ | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255" || (make ci:dump && exit 1);
 
 .PHONY: ci\:enable\:k8s
 ci\:enable\:k8s:


### PR DESCRIPTION
https://github.com/chatwork/charts/pull/12
上記PRの影響でci:diffおかしくなっていた問題を修正。

・ci:diffが適切に動作するように修正
・ci:diffの影響でgh-pagesへのpushで空になる問題を修正
・tgzがコミットできていなかった問題を修正
・テストに失敗したときにdumpを出力するように変更