### PR TITLE
[php] support hash annotation with configmap

### DIFF
--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -8,8 +8,9 @@ metadata:
     chart: {{ template "php.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.fpm.annotations }}
   annotations:
+    checksum/fpm-conf: {{ tpl (index .Values.fpm.templates "php-fpm.conf" | toYaml) . | sha256sum }}
+{{- with .Values.fpm.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 data:
@@ -25,6 +26,11 @@ metadata:
     chart: {{ template "php.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    checksum/fpm-confd: {{ tpl (index .Values.fpm.templates "php-fpm.d" | toYaml) . | sha256sum }}
+{{- with .Values.fpm.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 data:
 {{- $root := . -}}
 {{- range $k, $v := (index .Values.fpm.templates "php-fpm.d") }}

--- a/php/templates/configmap-nginx.yaml
+++ b/php/templates/configmap-nginx.yaml
@@ -8,8 +8,9 @@ metadata:
     chart: {{ template "php.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.nginx.annotations }}
   annotations:
+    checksum/nginx-conf: {{ tpl (index .Values.nginx.templates "nginx.conf" | toYaml) . | sha256sum }}
+{{- with .Values.nginx.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 data:
@@ -26,6 +27,11 @@ metadata:
     chart: {{ template "php.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    checksum/nginx-confd: {{ tpl (index .Values.nginx.templates "conf.d" | toYaml) . | sha256sum }}
+{{- with .Values.nginx.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 data:
 {{- $root := . -}}
 {{- range $k, $v := (index .Values.nginx.templates "conf.d") }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -23,8 +23,12 @@ spec:
         chart: {{ template "php.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-{{- with .Values.annotations }}
       annotations:
+        checksum/nginx-conf: {{ tpl (index .Values.nginx.templates "nginx.conf" | toYaml) . | sha256sum }}
+        checksum/nginx-confd: {{ tpl (index .Values.nginx.templates "conf.d" | toYaml) . | sha256sum }}
+        checksum/fpm-conf: {{ tpl (index .Values.fpm.templates "php-fpm.conf" | toYaml) . | sha256sum }}
+        checksum/fpm-confd: {{ tpl (index .Values.fpm.templates "php-fpm.d" | toYaml) . | sha256sum }}
+{{- with .Values.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:


### PR DESCRIPTION
https://www.chatwork.com/#!rid116733315-1107576369648238592
support hash annotation.

## testing

update configmap.

```
$ kc -n phpfec741eca36a137c945558422a61958129f382a7 get pod --watch                                               
NAME                                                            READY     STATUS      RESTARTS   AGE
php-fec741eca36a137c945558422a61958129f382a7-595d959d9f-j6t5x   2/2       Running     0          1m
php-fec741eca36a137c945558422a61958129f382a7-test               0/1       Completed   0          38m
php-fec741eca36a137c945558422a61958129f382a7-7db874774f-6xnf7   0/2       Pending   0         0s
php-fec741eca36a137c945558422a61958129f382a7-7db874774f-6xnf7   0/2       Pending   0         0s
php-fec741eca36a137c945558422a61958129f382a7-7db874774f-6xnf7   0/2       Init:0/1   0         0s
php-fec741eca36a137c945558422a61958129f382a7-7db874774f-6xnf7   0/2       PodInitializing   0         1s
php-fec741eca36a137c945558422a61958129f382a7-7db874774f-6xnf7   1/2       Running   0         3s
php-fec741eca36a137c945558422a61958129f382a7-7db874774f-6xnf7   2/2       Running   0         18s
php-fec741eca36a137c945558422a61958129f382a7-595d959d9f-j6t5x   2/2       Terminating   0         1m
php-fec741eca36a137c945558422a61958129f382a7-595d959d9f-j6t5x   0/2       Terminating   0         1m
```

It is terminated after POD is created.