### PR TITLE
STRIX-36: Ingress に preferPaths を追加

### DIFF
--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "php.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPort := .Values.ingress.port -}}
+{{- $ingressPreferPaths := .Values.ingress.preferPaths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -31,6 +32,9 @@ spec:
     - host: {{ . }}
       http:
         paths:
+{{- with $ingressPreferPaths }}
+{{ toYaml . | indent 10 }}
+{{- end }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -745,6 +745,7 @@ service:
 
 ingress:
   enabled: false
+  preferPaths: []
 
 # If you need it you can write raw Kubernetes Config
 # extras:


### PR DESCRIPTION
https://chatwork.atlassian.net/browse/STRIX-36

## 内容

* 緊急メンテナンスのように一時的に path を追加する場合を想定して、`preferPaths` を追加。
* `preferPaths` で指定した path は、上位に登録されるのでこちらが優先となる。

## 動作確認

`helm template` で出力されたマニフェストで確認。

* `preferPaths` なし
```
$ helm template --set "ingress.patht=/*" --set ingress.port=8000 --set ingress.enabled=true --set "ingress.hosts[0]=www.example.com" -x templates/ingress.yaml --name php .
---
# Source: php/templates/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: php
  labels:
    app: php
    chart: php-0.5.0
    release: php
    heritage: Tiller
spec:
  rules:
    - host: www.example.com
      http:
        paths:
          - path:
            backend:
              serviceName: php
              servicePort: 8000
```

* `preferPaths` あり
```
helm template --set "ingress.path=/*" --set ingress.port=8000 --set ingress.enabled=true --set "ingress.hosts[0]=www.example.com" --set "ingress.preferPaths[0].path=/*" --set "ingress.preferPaths[0].backend.serviceName=sample"  --set "ingress.preferPaths[0].backend.servicePort=use-annotation" -x templates/ingress.yaml --name php .
---
# Source: php/templates/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: php
  labels:
    app: php
    chart: php-0.5.0
    release: php
    heritage: Tiller
spec:
  rules:
    - host: www.example.com
      http:
        paths:
          - backend:
              serviceName: sample
              servicePort: use-annotation
            path: /*

          - path: /*
            backend:
              serviceName: php
              servicePort: 8000
```