### PR TITLE
[regcred] Changed to use specified name

### DIFF
--- a/regcred/Chart.yaml
+++ b/regcred/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Pull an Image from a Private Registry
 name: regcred
-version: 0.1.0
+version: 0.1.1
 maintainers:
 - name: cw-ozaki
   email: ozaki@chatwork.com

--- a/regcred/README.md
+++ b/regcred/README.md
@@ -1,0 +1,48 @@
+# Regcred
+
+Regcred creates [Secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to pull the image from the Private Registry.
+
+## Installing the Chart
+
+To install the chart with the release name `regcred`:
+
+```
+$ helm install --name regcred \
+    --set server=https://index.docker.io/v1/ \
+    --set username=[your username] \
+    --set password=[your password] \
+    --set email=[your email] \
+    chatwork/regcred
+```
+
+Pulling image from Private Registry by specifying `imagePullSecrets[].name` like this:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: private-reg
+spec:
+  containers:
+  - name: private-reg-container
+    image: <your-private-image>
+  imagePullSecrets:
+  - name: regcred
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the regcred chart and their default values.
+
+|             Parameter       |            Description             |                    Default                |
+|-----------------------------|------------------------------------|-------------------------------------------|
+| `regcred.server`            | Docker registry URL                | `https://index.docker.io/v1/`             |
+| `regcred.username`          | Username to login on Docker registry | `""`                                    |
+| `regcred.password`          | Password to login on Docker registry | `""`                                    |
+| `regcred.email`             | Email address of Docker registry   | `""`                                      |
+| `regcred.dockerconfigjson`  | Encoded authentication information. used when not using user name and password. | `Nil` |
+
+### Secret
+
+You can choose between `username`/`password` and `dockerconfigjson`.
+If you use `dockerconfigjson`, please refer to the [link](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#inspecting-the-secret-regcred).

--- a/regcred/templates/secret.yaml
+++ b/regcred/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: regcred
+  name: {{ template "regcred.name" . }}
   labels:
     app: {{ template "regcred.name" . }}
     chart: {{ template "regcred.chart" . }}


### PR DESCRIPTION
```
$ helm install --name xxx ... chatwork/regcred
```

Fix to be able to create a secret with the specified name `xxx`.