### PR TITLE
add slime chart

### DIFF
--- a/slime/.helmignore
+++ b/slime/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/slime/Chart.yaml
+++ b/slime/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: ₍Ꙭ̂₎ < Not my bad slime
+name: slime
+version: 0.1.0
+maintainers:
+- name: cw-ozaki
+  email: ozaki@chatwork.com
+  url: https://github.com/cw-ozaki

--- a/slime/Makefile
+++ b/slime/Makefile
@@ -3,7 +3,11 @@ apply:
 	@if ! kubectl get namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" >/dev/null 2>&1; then \
 		kubectl create namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)"; \
 	fi
-	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) .;
+	@if [ -n "$${CI}" ]; then \
+		helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) --set 'configmaps[0].data.slime=₍Ꙭ̂₎' --set 'configmaps[0].metadata.name=slime' .; \
+	else \
+		helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) .; \
+	fi
 
 .PHONY: test
 test:

--- a/slime/Makefile
+++ b/slime/Makefile
@@ -1,0 +1,15 @@
+.PHONY: apply
+apply:
+	@if ! kubectl get namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" >/dev/null 2>&1; then \
+		kubectl create namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)"; \
+	fi
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) .;
+
+.PHONY: test
+test:
+	echo "no test"
+
+.PHONY: delete
+delete:
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} ls -q \
+		| xargs -I {} helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} delete --purge $$(basename $$PWD)-$$(git rev-parse --short HEAD);

--- a/slime/README.md
+++ b/slime/README.md
@@ -1,0 +1,45 @@
+# slime
+
+₍Ꙭ̂₎ < Not my bad slime
+
+₍Ꙭ̂₎ < I will transform into anything
+
+## TL;DR;
+
+```
+$ helm install chatwork/slime
+```
+
+## Prerequisites
+
+* Kubernetes 1.11+
+
+## Installing the Chart
+
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install --name my-release chatwork/slime
+```
+
+The command deploys the slime chart on the Kubernetes cluster in the default configuration. The [configuration](https://github.com/chatwork/charts/tree/master/slime#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the slime chart and their default values.
+
+|  Parameter | Description | Default |
+| --- | --- | --- |
+|  `configmaps` | Transform ConfigMap's YAML. You can set `binaryData`, `data` and `metadata` | `[]` |
+|  `secret` | Transform Secret's YAML. You can set `data`, `metadata`, `stringData` and `type` | `[]` |

--- a/slime/templates/_helpers.tpl
+++ b/slime/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "slime.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "slime.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "slime.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/slime/templates/configmap.yaml
+++ b/slime/templates/configmap.yaml
@@ -1,0 +1,35 @@
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#configmap-v1-core
+{{- $root := . }}
+{{- range $index, $value := .Values.configmaps }}
+apiVersion: v1
+{{- with $value.binaryData }}
+binaryData:
+{{ . | toYaml | indent 2 }}
+{{- end }}
+{{- with $value.data }}
+data:
+{{ . | toYaml | indent 2 }}
+{{- end }}
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "slime.name" $root }}
+    chart: {{ template "slime.chart" $root }}
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+{{- range $key, $val := $value.metadata.label }}
+{{- if not (regexMatch "^(app|chart|release|heritage)$" $key) }}
+    {{ $key }}: {{ $val }}
+{{- end }}
+{{- end }}
+{{- range $key, $val := $value.metadata }}
+{{- if ne $key "label" }}
+{{- if regexMatch "^(string|bool|int|float64)$" (printf "%T" $val) }}
+  {{ $key }}: {{ $val }}
+{{- else }}
+  {{ $key }}:
+{{ toYaml $val | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/slime/templates/configmap.yaml
+++ b/slime/templates/configmap.yaml
@@ -17,13 +17,14 @@ metadata:
     chart: {{ template "slime.chart" $root }}
     release: {{ $root.Release.Name }}
     heritage: {{ $root.Release.Service }}
-{{- range $key, $val := $value.metadata.label }}
-{{- if not (regexMatch "^(app|chart|release|heritage)$" $key) }}
-    {{ $key }}: {{ $val }}
-{{- end }}
-{{- end }}
 {{- range $key, $val := $value.metadata }}
-{{- if ne $key "label" }}
+{{- if eq $key "labels" }}
+{{- range $k, $v := $value.metadata.labels }}
+{{- if not (regexMatch "^(app|chart|release|heritage)$" $k) }}
+    {{ $k }}: {{ $v }}
+{{- end }}
+{{- end }}
+{{- else }}
 {{- if regexMatch "^(string|bool|int|float64)$" (printf "%T" $val) }}
   {{ $key }}: {{ $val }}
 {{- else }}

--- a/slime/templates/secret.yaml
+++ b/slime/templates/secret.yaml
@@ -1,0 +1,41 @@
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#secret-v1-core
+{{- $root := . }}
+{{- range $index, $value := .Values.secrets }}
+apiVersion: v1
+{{- with $value.data }}
+data:
+{{- range $k, $v :=  $value.data }}
+  {{ $k }}: {{ . | b64enc | quote }}
+{{- end }}
+kind: Secret
+metadata:
+  labels:
+  app: {{ template "slime.name" $root }}
+  chart: {{ template "slime.chart" $root }}
+  release: {{ $root.Release.Name }}
+  heritage: {{ $root.Release.Service }}
+{{- range $key, $val := $value.metadata.label }}
+{{- if not (regexMatch "^(app|chart|release|heritage)$" $key) }}
+    {{ $key }}: {{ $val }}
+{{- end }}
+{{- end }}
+{{- range $key, $val := $value.metadata }}
+{{- if ne $key "label" }}
+{{- if regexMatch "^(string|bool|int|float64)$" (printf "%T" $val) }}
+  {{ $key }}: {{ $val }}
+{{- else }}
+  {{ $key }}:
+{{ toYaml $val | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with $value.stringData }}
+stringData:
+{{ . | toYaml | indent 2 }}
+{{- end }}
+{{- with $value.type }}
+type:
+{{ . | toYaml | indent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/slime/templates/secret.yaml
+++ b/slime/templates/secret.yaml
@@ -10,17 +10,18 @@ data:
 kind: Secret
 metadata:
   labels:
-  app: {{ template "slime.name" $root }}
-  chart: {{ template "slime.chart" $root }}
-  release: {{ $root.Release.Name }}
-  heritage: {{ $root.Release.Service }}
-{{- range $key, $val := $value.metadata.label }}
-{{- if not (regexMatch "^(app|chart|release|heritage)$" $key) }}
-    {{ $key }}: {{ $val }}
-{{- end }}
-{{- end }}
+    app: {{ template "slime.name" $root }}
+    chart: {{ template "slime.chart" $root }}
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
 {{- range $key, $val := $value.metadata }}
-{{- if ne $key "label" }}
+{{- if eq $key "labels" }}
+{{- range $k, $v := $value.metadata.labels }}
+{{- if not (regexMatch "^(app|chart|release|heritage)$" $k) }}
+    {{ $k }}: {{ $v }}
+{{- end }}
+{{- end }}
+{{- else }}
 {{- if regexMatch "^(string|bool|int|float64)$" (printf "%T" $val) }}
   {{ $key }}: {{ $val }}
 {{- else }}

--- a/slime/values.yaml
+++ b/slime/values.yaml
@@ -1,0 +1,19 @@
+# Default values for example.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+configmaps: []
+#- metadata:
+#    name: slime
+#    annotations:
+#      foo: bar
+#  data:
+#    slime: '₍Ꙭ̂₎'
+
+secrets: []
+#- metadata:
+#    name: slime
+#    annotations:
+#      foo: bar
+#  data:
+#    slime: '₍Ꙭ̂₎'


### PR DESCRIPTION
₍Ꙭ̂₎ < Not my bad slime

## Usecase

We may need a specific Kubernetes Resouce.
For example in nginx-ingress when defining secret for TLS in helmfile.

So we have made Slime Chart to make a simple Kubernetes Resource to solve the problem.

Note: We do not place importance on building services like cloudposse/monochart. Slime only fills the gap.

## Other resources

Now only `ConfigMap` and `Secrets` support.
Other resources will be supported when needed.