### PR TITLE
[php] add service extra port

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.7.0
+version: 0.8.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `affinity` | Node / Pod affinities | `{}` |
 |  `service.type` | Changes to ClusterIP automatically if ingress enabled | `LoadBalancer` |
 |  `service.port` | Port to advertise the main web service in LoadBalancer mode | `8080` |
+|  `service.extraPorts` | Additional ports | `8080` |
 |  `ingress.enabled` | Enables Ingress | `FALSE` |
 |  `ingress.annotation` | Ingress annotations |  |
 |  `ingress.host` | Ingress accepted hostname | nginx.host |

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
         imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
         ports:
-        - name: http
+        - name: default
           containerPort: {{ .Values.nginx.port }}
           protocol: TCP
 {{- with .Values.nginx.extraPorts }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
 {{- end }}
 
   rules:
-    - host: {{ .Values.ingress.host | .Values.nginx.host }}
+    - host: {{ .Values.ingress.host | default .Values.nginx.host }}
       http:
         paths:
 {{- with .Values.ingress.preferPaths }}

--- a/php/templates/service.yaml
+++ b/php/templates/service.yaml
@@ -14,10 +14,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port | default .Values.nginx.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+  - port: {{ .Values.service.port | default .Values.nginx.port }}
+    targetPort: default
+    protocol: TCP
+    name: default
   selector:
     app: {{ template "php.name" . }}
     release: {{ .Release.Name }}

--- a/php/templates/service.yaml
+++ b/php/templates/service.yaml
@@ -14,10 +14,20 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.service.port | default .Values.nginx.port }}
-    targetPort: default
+  - name: default
+    port: {{ .Values.service.port | default .Values.nginx.port }}
     protocol: TCP
-    name: default
+    targetPort: default
+{{- if .Values.service.extraPorts }}
+{{ .Values.service.extraPorts | toYaml | indent 2}}
+{{- else }}
+{{- range .Values.nginx.extraPorts }}
+  - name: {{ .name }}
+    port: {{ .containerPort }}
+    {{- with .protocol }}protocol: {{ . }}{{ end }}
+    targetPort: {{ .name | default .containerPort }}
+{{- end }}
+{{- end }}
   selector:
     app: {{ template "php.name" . }}
     release: {{ .Release.Name }}

--- a/php/templates/test/test-pod.yaml
+++ b/php/templates/test/test-pod.yaml
@@ -19,7 +19,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          curl http://{{ template "php.fullname" . }}:{{ .Values.service.port | default "80" }}
+          curl http://{{ template "php.fullname" . }}:{{ .Values.service.port | default .Values.nginx.port }}
 {{- with .Values.test.extraContainer }}
 {{ toYaml . | indent 8}}
 {{- end }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -22,7 +22,7 @@ affinity: {}
 # SERVICE
 service:
   type: LoadBalancer
-  port: 8080
+  extraPorts: []
 
 # INGRESS
 ingress:


### PR DESCRIPTION
Support `service.extraPorts`.
It is used for applications that expose multiple ports (e.g. 80/443) as use cases.