### PR TITLE
[php] change type of fpm.extraEnv to YAML list

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -118,7 +118,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `fpm.livenessProbe` | Overrides the default liveness probe | `{}` |
 |  `fpm.readinessProbe` | Overrides the default readness probe | `{}` |
 |  `fpm.resources` | Overrides the default resource | `{}` |
-|  `fpm.extraEnv` | Additional environment variables | `{}` |
+|  `fpm.extraEnv` | Additional env | `[]` |
 |  `fpm.extraEnvFrom` | Additional envFrom | `[]` |
 |  `fpm.extraPorts` | Additional ports | `[]` |
 |  `fpm.extraVolumes` | Additional volumes | `[]` |

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -139,10 +139,7 @@ spec:
 {{- end }}
 {{- with .Values.fpm.extraEnv }}
         env:
-{{- range $k, $v := . }}
-        - name: {{ $k }}
-          value: {{ $v }}
-{{- end }}
+{{ tpl (toYaml .) $root | indent 10 }}
 {{- end }}
 {{- with .Values.fpm.extraEnvFrom }}
         envFrom:

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -303,10 +303,13 @@ fpm:
   resources: {}
 
   # `fpm.extraEnv` is additional environment variables.
-  extraEnv: {}
-  #  KEY1: VALUE1
-  #  KEY2: VALUE2
-  #  KEY3: VALUE3
+  extraEnv: []
+  #- name: key1
+  #  value: value1
+  #- name: HOST_IP
+  #  valueFrom:
+  #    fieldRef:
+  #      fieldPath: status.hostIP
 
   # `fpm.extraEnvFrom` is addtional envFrom.
   # Specify ConfigMap created in `fpm.templates` or Secret created in `fpm.secrets`.


### PR DESCRIPTION
This PR adds support for valueFrom key in fpm.extraEnv.

* example(values.yaml)

```
fpm:
  extraEnv:
    - name: HOST_IP
      valueFrom:
        fieldRef:
          fieldPath: status.hostIP
```