### PR TITLE
[postfix] replace MailHog with MailCatcher

### DIFF
--- a/postfix/Makefile
+++ b/postfix/Makefile
@@ -2,10 +2,11 @@ namespace = "$$(basename $$PWD)$$(git rev-parse HEAD)"
 helmContext = --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"}
 releaseName = $$(basename $$PWD)-$$(git rev-parse HEAD)
 
-helmInstallOptions = --wait --install --namespace $(namespace) --set terminationGracePeriodSeconds=1
+helmInstallOptions = --wait --install --namespace $(namespace) --set terminationGracePeriodSeconds=0
 deleteTestPod = kubectl delete pods --namespace $(namespace) $(releaseName)-test
 deleteChart = helm $(helmContext) delete $(releaseName) --purge
 helmTest = helm $(helmContext) test $(releaseName)
+mailcatcher = --set mailcatcher.enabled=true --set mailcatcher.service.type=ClusterIP
 
 .PHONY: apply
 apply:
@@ -16,7 +17,7 @@ apply:
 	helm $(helmContext) upgrade $(helmInstallOptions) -f templates/test/test-hostPath-values.yaml $(releaseName) .;
 
 .PHONY: test
-test: test-daemonset test-daemonset-mailhog test-deployment test-deployment-mailhog
+test: test-daemonset test-daemonset-mailcatcher test-deployment test-deployment-mailcatcher
 
 .PHONY: test-daemonset
 test-daemonset:
@@ -27,12 +28,12 @@ test-daemonset:
 
 	$(helmTest)
 
-.PHONY: test-daemonset-mailhog
-test-daemonset-mailhog:
+.PHONY: test-daemonset-mailcatcher
+test-daemonset-mailcatcher:
 	-$(deleteTestPod)
 	-$(deleteChart)
 
-	helm $(helmContext) upgrade $(helmInstallOptions) -f templates/test/test-hostPath-values.yaml --set mailhog.enabled=true $(releaseName) .;
+	helm $(helmContext) upgrade $(helmInstallOptions) -f templates/test/test-hostPath-values.yaml $(mailcatcher) $(releaseName) .;
 	$(helmTest)
 
 .PHONY: test-deployment
@@ -46,14 +47,14 @@ test-deployment:
 
 	$(helmTest)
 
-.PHONY: test-deployment-mailhog
-test-deployment-mailhog:
+.PHONY: test-deployment-mailcatcher
+test-deployment-mailcatcher:
     # Chart を削除して再生成すると、test-pod では古い Service の IP を引いてしまうので削除しない。
 	-$(deleteTestPod)
 
 	# kubeadm-dind-cluster 環境で Service を利用する場合、type=LoadBalancer だと 起動しない。ClusterIP を指定して回避。
 	# @see https://github.com/kubernetes-sigs/kubeadm-dind-cluster/issues/74
-	helm $(helmContext) upgrade $(helmInstallOptions) --set deployment.enabled=true --set daemonset.enabled=false --set mailhog.enabled=true --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP  $(releaseName) .;
+	helm $(helmContext) upgrade $(helmInstallOptions) --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP  $(releaseName) .;
 
 	$(helmTest)
 

--- a/postfix/templates/dev-mailcatcher.yaml
+++ b/postfix/templates/dev-mailcatcher.yaml
@@ -1,53 +1,56 @@
-{{- if .Values.mailhog.enabled }}
+{{- $root := .Values.mailcatcher -}}
+{{- if $root.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "postfix.fullname" . }}-mailhog
+  name: {{ include "postfix.fullname" . }}-mailcatcher
   labels:
-    app: {{ include "postfix.name" . }}-mailhog
+    app: {{ include "postfix.name" . }}-mailcatcher
     chart: {{ include "postfix.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: NodePort
+  type: {{ $root.service.type }}
   ports:
     - port: 1025
+      targetPort: 1025
       protocol: TCP
       name: smtp
-    - port: 8025
-      nodePort: {{ .Values.mailhog.hostHttpPort }}
+    - port: {{ $root.service.httpPort }}
+      targetPort: 1080
       protocol: TCP
       name: http
   selector:
-    app: {{ include "postfix.name" . }}-mailhog
+    app: {{ include "postfix.name" . }}-mailcatcher
     release: {{ .Release.Name }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "postfix.fullname" . }}-mailhog
+  name: {{ include "postfix.fullname" . }}-mailcatcher
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "postfix.name" . }}-mailhog
+      app: {{ include "postfix.name" . }}-mailcatcher
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "postfix.name" . }}-mailhog
+        app: {{ include "postfix.name" . }}-mailcatcher
         chart: {{ template "postfix.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}-mailhog
-          image: mailhog/mailhog
+        - name: {{ include "postfix.name" . }}-mailcatcher
+          image: "{{ $root.image.repository }}:{{ $root.image.tag }}"
+          imagePullPolicy: {{ $root.image.pullPolicy }}
           ports:
             - name: smtp
               containerPort: 1025
               protocol: TCP
             - name: http
-              containerPort: 8025
+              containerPort: 1080
               protocol: TCP
 {{- end }}

--- a/postfix/templates/test/test-pod-mailcatcher.yaml
+++ b/postfix/templates/test/test-pod-mailcatcher.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mailhog.enabled }}
+{{- if .Values.mailcatcher.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -16,10 +16,10 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
       {{- end }}
-        - name: MAILHOG_HOST
-          value: {{ include "postfix.fullname" . }}-mailhog
-        - name: MAILHOG_HTTP_PORT
-          value: "8025"
+        - name: MAILCATCHER_HOST
+          value: {{ include "postfix.fullname" . }}-mailcatcher
+        - name: MAILCATCHER_HTTP_PORT
+          value: "{{ .Values.mailcatcher.service.httpPort }}"
         - name: TO_EMAIL
           value: {{ .Values.test.toEmail }}
       command:
@@ -34,6 +34,6 @@ spec:
         {{- end }}
           && /usr/local/bin/php -r "\$ret = mail(\"${TO_EMAIL}\", \"Hello\", \"Body\"); var_dump(\$ret);" | grep true \
           && sleep 1 \
-          && curl http://${MAILHOG_HOST}:${MAILHOG_HTTP_PORT}/api/v2/messages | grep ${TO_EMAIL}
+          && curl http://${MAILCATCHER_HOST}:${MAILCATCHER_HTTP_PORT}/messages | grep ${TO_EMAIL}
   restartPolicy: Never
 {{- end }}

--- a/postfix/templates/test/test-pod.yaml
+++ b/postfix/templates/test/test-pod.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mailhog.enabled }}
+{{- if not .Values.mailcatcher.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -762,10 +762,10 @@ postfix:
       meta_directory = /etc/postfix
       shlib_directory = /usr/lib/postfix
 
-      {{- if .Values.mailhog.enabled }}
+      {{- if .Values.mailcatcher.enabled }}
       # Postfix の名前解決では、サービス名が引けないので native を指定
       smtp_host_lookup = native
-      relayhost = [{{ include "postfix.fullname" . }}-mailhog]:1025
+      relayhost = [{{ include "postfix.fullname" . }}-mailcatcher]:1025
       {{- else }}
       # @see https://sendgrid.kke.co.jp/docs/Integrate/Mail_Servers/postfix.html
       smtp_sasl_auth_enable = yes
@@ -777,7 +777,7 @@ postfix:
       relayhost = [smtp.sendgrid.net]:587
       {{- end }}
   secrets:
-    # duumy value
+    # dummy value
     # @see https://sendgrid.kke.co.jp/docs/Integrate/Mail_Servers/postfix.html
     sasl_passwd: |-
       [smtp.sendgrid.net]:587 yourSendGridUsername:yourSendGridPassword
@@ -788,14 +788,19 @@ test:
   toEmail: "a@example.com"
 
 # for dev
-# mailhog.enabled=true にすると以下が有効になる。
-# - MailHog サービス（templates/dev-mailhog.yaml）が起動する。
-# - 全てのメールが MailHog にリレーされる。
+# mailcatcher.enabled=true にすると以下が有効になる。
+# - MailCatcher サービス（templates/dev-mailcatcher.yaml）が起動する。
+# - 全てのメールが MailCatcher にリレーされる。
 #
 # 開発環境、helm test 用の機能なので、本番運用では false にしておく。
-mailhog:
+mailcatcher:
   enabled: false
-  # MailHog HTTP ポート
-  # Docker for Mac では http://localhost:30080/ でアクセスできる
-  hostHttpPort: 30080
-
+  image:
+    repository: chatwork/mailcatcher
+    tag: latest
+    pullPolicy: IfNotPresent
+  # MailCatcher HTTP ポート
+  # Docker for Mac では http://localhost:1080/ でアクセスできる
+  service:
+    type: LoadBalancer
+    httpPort: 1080


### PR DESCRIPTION
This PR replaces MailHog with MailCatcher.
Because MailHog Web UI can not display iso-2022-jp encoded mail correctly.

<img width="501" alt="mailhog" src="https://user-images.githubusercontent.com/88324/55855314-25e36580-5ba2-11e9-9035-91f874a796e5.png">

MailCatcher Web UI can display it correctly.

<img width="542" alt="mailcatcher" src="https://user-images.githubusercontent.com/88324/55855318-2845bf80-5ba2-11e9-971d-3c2b6930f9e7.png">
