### PR TITLE
[php] support ingress multi host

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.10.0
+version: 0.11.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -54,11 +54,10 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `service.extraPorts` | Additional ports | `8080` |
 |  `ingress.enabled` | Enables Ingress | `FALSE` |
 |  `ingress.annotation` | Ingress annotations |  |
-|  `ingress.host` | Ingress accepted hostname | nginx.host |
+|  `ingress.hosts` | Ingress accepted hostname | `[]` |
 |  `ingress.port` | Ingress port | service.port or nginx.port |
-|  `ingress.path` | Ingress path |  |
 |  `ingress.preferPaths` | Paths that takes precedence over the ingress.path |  |
-|  `ingress.tls.secretName` | TLS Secret (certificates) name  |  |
+|  `ingress.tls` | TLS Secret (certificates)  |  |
 |  `podDisruptionBudget.enabled` | If true, create a pod disruption budget for keeper pods | `FALSE` |
 |  `podDisruptionBudget.minAvailabled` | Minimum number / percentage of pods that should remain scheduled |  |
 |  `podDisruptionBudget.maxAvailabled` | Minimum number / percentage of pods that should remain scheduled |  |

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 {{- if .Values.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -18,20 +19,19 @@ spec:
     servicePort: {{ .Values.ingress.port | default .Values.service.port | default .Values.nginx.port }}
 {{- if .Values.ingress.tls }}
   tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.ingress.tls.secretName }}
+{{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end }}
-
   rules:
-    - host: {{ .Values.ingress.host | default .Values.nginx.host }}
-      http:
-        paths:
-{{- with .Values.ingress.preferPaths }}
-{{ toYaml . | indent 10 }}
+{{- range $k, $host := .Values.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+{{- with $root.Values.ingress.preferPaths }}
+{{ toYaml . | indent 6 }}
 {{- end }}
-          - path: {{ .Values.ingress.path }}
-            backend:
-              serviceName: {{ template "php.fullname" . }}
-              servicePort: {{ .Values.ingress.port | default .Values.service.port | default .Values.nginx.port }}
+      - path: /*
+        backend:
+          serviceName: {{ template "php.fullname" $root }}
+          servicePort: {{ $root.Values.service.port | default $root.Values.nginx.port }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Ingress supports multiple hosts for domain routing with NGINX.

NOTE: Domain routing should be resolved in ingress. 
However, Ingress has many limitations. However, because I have many limitations in ingress, I do routing with NGINX.