### PR TITLE
[php] add fpm.command

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -116,6 +116,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `fpm.image.repository` | The image repository to pull from | `php` |
 |  `fpm.image.tag` | The image tag to pull | `7.1-fpm-alpine` |
 |  `fpm.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+|  `fpm.command` | Overrides the default command | `[]` |
 |  `fpm.ini` | Override the default php.ini. Please specify the parameter name with Lower Camel Case |  |
 |  `fpm.livenessProbe` | Overrides the default liveness probe | `{}` |
 |  `fpm.readinessProbe` | Overrides the default readness probe | `{}` |

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -141,6 +141,10 @@ spec:
       - name: "{{ template "php.fullname" . }}-fpm"
         image: "{{ .Values.fpm.image.repository }}:{{ .Values.fpm.image.tag }}"
         imagePullPolicy: {{ .Values.fpm.image.pullPolicy }}
+{{- with .Values.fpm.command }}
+        command:
+{{ tpl (toYaml .) $root | indent 8 }}
+{{- end }}
 {{- with .Values.fpm.extraPorts }}
         ports:
 {{- range $v := . }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -280,6 +280,12 @@ fpm:
     tag: 7.1-fpm-alpine
     pullPolicy: IfNotPresent
 
+  # custom command for php-fpm image execution
+  command: []
+  # command:
+  # - php-fpm
+  # - -d zend_extension=xdebug.so
+
   # PHP-FPM configuration
   # http://php.net/manual/en/install.fpm.configuration.php
   ## global configuration


### PR DESCRIPTION
This PR adds `fpm.command` to customize command in the php-fpm image.

You can use it to override command for the fpm container, as shown below.

```sh
# default
$ helm template --name php . > default.yaml
# customize command
$ helm template --set "fpm.command[0]=php-fpm" --set "fpm.command[1]=-dzend_extension=xdebug.so" --name php . > command_customized.yaml

$ diff -u default.yaml command_customized.yaml
--- default.yaml        2019-06-12 15:38:19.000000000 +0900
+++ command_customized.yaml     2019-06-12 16:05:18.000000000 +0900
@@ -814,6 +814,10 @@
       - name: "php-fpm"
         image: "php:7.1-fpm-alpine"
         imagePullPolicy: IfNotPresent
+        command:
+        - php-fpm
+        - -dzend_extension=xdebug.so
+
         lifecycle:
           preStop:
             exec:

```