### PR TITLE
[php] fix wrong indent in configmap-fpm.yaml

### DIFF
--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -59,7 +59,7 @@ metadata:
 {{- with $fpm.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-  data:
+data:
 {{ tpl (toYaml $tmpl) $root | indent 2 }}
 {{- end}}
 {{- end }}


### PR DESCRIPTION
The indent was broken. This PR fix it.