### PR TITLE
[php] fixes type check

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.13.1
+version: 0.13.2
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -923,10 +923,12 @@ fpm:
         php_admin_value[error_log] = /dev/stderr
         php_admin_flag[log_errors] = on
         {{- range $k, $v := .Values.fpm.ini }}
-        {{- if eq (print "%t" $v) "true" }}
+        {{- if eq (printf "%t" $v) "true" }}
         php_flag[{{ snakecase $k }}] = on
-        {{- else if eq (print "%t" $v) "false" }}
+        {{- else if eq (printf "%t" $v) "false" }}
         php_flag[{{ snakecase $k }}] = off
+        {{- else if eq (printf "%T" $v) "string" }}
+        php_value[{{ snakecase $k }}] = "{{ $v }}"
         {{- else }}
         php_value[{{ snakecase $k }}] = {{ $v }}
         {{- end }}


### PR DESCRIPTION
The evaluation result of `print "%t"` becomes `%t`.
This is a mistake and we should use `printf` correctly.