### PR TITLE
[elasticmq] add extraVolumes and extraVolumeMounts

### DIFF
--- a/elasticmq/templates/deployment.yaml
+++ b/elasticmq/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - name: conf
               subPath: elasticmq_conf
               mountPath: /opt/elasticmq.conf
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+{{- end }}
 {{- with .Values.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -55,6 +58,9 @@ spec:
         - name: conf
           configMap:
             name: {{ template "elasticmq.fullname" . }}
+{{- with .Values.extraVolumes }}
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}

--- a/elasticmq/values.yaml
+++ b/elasticmq/values.yaml
@@ -37,6 +37,14 @@ elasticmq:
         sqs-limits = relaxed
     }
 
+extraVolumeMounts: []
+#  - name: data
+#    mountPath: /data
+
+extraVolumes: []
+#  - name: data
+#    emptyDir: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR allows to inject extra volumes and volumeMounts.

Here is an example of how to use the added values.

```bash
$ helm template --name elasticmq . > a.yaml

# added values
$ helm template --name elasticmq --set extraVolumes\[0\].name=data --set extraVolumes\[0\].mountPath=/data --set extraVolumeMounts\[0\].name=data --set extraVolumeMounts\[0\].path=/mount/data . > b.yaml

$ diff -u a.yaml b.yaml
--- a.yaml      2019-09-11 17:40:24.000000000 +0900
+++ b.yaml      2019-09-11 17:40:14.000000000 +0900
@@ -134,8 +134,14 @@
             - name: conf
               subPath: elasticmq_conf
               mountPath: /opt/elasticmq.conf
+            - name: data
+              path: /mount/data
+
       volumes:
         - name: conf
           configMap:
             name: elasticmq
+        - mountPath: /data
+          name: data
+
```