### PR TITLE
[php] add postStart to nginx and fpm

### DIFF
--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -114,6 +114,12 @@ spec:
 {{ tpl (toYaml .) $root | indent 10 }}
 {{- end }}
         lifecycle:
+{{- with .Values.nginx.lifecycle.postStart }}
+          postStart:
+            exec:
+              command:
+{{ tpl (toYaml .) $root | indent 14 }}
+{{- end }}
           preStop:
             exec:
               command: ["sh", "-c", "sleep {{ .Values.fpm.processControlTimeout | default 0 }}; nginx -s quit; sleep 5"]
@@ -172,6 +178,12 @@ spec:
 {{ tpl (toYaml .) $root | indent 10 }}
 {{- end }}
         lifecycle:
+{{- with .Values.fpm.lifecycle.postStart }}
+          postStart:
+            exec:
+              command:
+{{ tpl (toYaml .) $root | indent 14 }}
+{{- end }}
           preStop:
             exec:
               command: ["sh", "-c", "sleep 1; kill -QUIT 1; sleep {{ .Values.fpm.processControlTimeout | default 0 }}"]

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -128,6 +128,10 @@ nginx:
   host: localhost # host using as Ingress host name
   port: 80        # port using as Container port, Service port, Ingress port
 
+  lifecycle:
+    postStart: []
+    # postStart: ["/bin/sh", "-c", "echo Hello > /tmp/message"]
+
   livenessProbe:
     httpGet:
       path: /status
@@ -285,6 +289,10 @@ fpm:
   # command:
   # - php-fpm
   # - -d zend_extension=xdebug.so
+
+  lifecycle:
+    postStart: []
+    # postStart: ["/bin/sh", "-c", "echo Hello > /tmp/message"]
 
   # PHP-FPM configuration
   # http://php.net/manual/en/install.fpm.configuration.php


### PR DESCRIPTION
This PR allows to add postStart commands to nginx and fpm pods.

Example of execution is below.

```
$ helm template --name php . > a.yaml

$ helm template \
--set nginx.lifecycle.postStart\[0\]="/bin/sh" \
--set nginx.lifecycle.postStart\[1\]="-c" \
--set nginx.lifecycle.postStart\[2\]="echo 'nginx'" \
--set fpm.lifecycle.postStart\[0\]="/bin/sh" \
--set fpm.lifecycle.postStart\[1\]="-c" \
--set fpm.lifecycle.postStart\[2\]="echo 'fpm'" \
--name php . > b.yaml

$ diff -u a.yaml b.yaml
--- a.yaml      2019-11-06 12:56:50.000000000 +0900
+++ b.yaml      2019-11-06 12:56:55.000000000 +0900
@@ -798,6 +798,13 @@
           timeoutSeconds: 1

         lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - echo 'nginx'
+
           preStop:
             exec:
               command: ["sh", "-c", "sleep 0; nginx -s quit; sleep 5"]
@@ -815,6 +822,13 @@
         image: "php:7.1-fpm-alpine"
         imagePullPolicy: IfNotPresent
         lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - echo 'fpm'
+
           preStop:
             exec:
               command: ["sh", "-c", "sleep 1; kill -QUIT 1; sleep 0"]
```


