### PR TITLE
Create phpini file

### DIFF
--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -9,13 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    checksum/fpm-php-ini: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
+    checksum/fpm-php-ini: {{ tpl (index .Values.fpm.ini | toYaml) . | sha256sum }}
 {{- with .Values.fpm.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 data:
-  php.ini:
-{{- tpl (index .Values.fpm.templates "php.ini") . | toYaml | indent 2 }}
+  php.ini: |
+{{ .Values.fpm.ini  | indent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -9,13 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    checksum/fpm-php-ini: {{ tpl (index .Values.fpm.ini | toYaml) . | sha256sum }}
+    checksum/fpm-php-ini: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
 {{- with .Values.fpm.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 data:
-  php.ini: |
-{{ .Values.fpm.ini  | indent 4 }}
+  php.ini:
+{{- tpl (index .Values.fpm.templates "php.ini") . | toYaml | indent 2 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "php.fullname" . }}-fpm-phpini
+  name: {{ template "php.fullname" . }}-fpm-php-ini
   labels:
     app: {{ template "php.name" . }}
     chart: {{ template "php.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    checksum/fpm-phpini: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
+    checksum/fpm-php-ini: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
 {{- with .Values.fpm.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -2,6 +2,24 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: {{ template "php.fullname" . }}-fpm-phpini
+  labels:
+    app: {{ template "php.name" . }}
+    chart: {{ template "php.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    checksum/fpm-php-fpm-conf: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
+{{- with .Values.fpm.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+data:
+  php.ini:
+{{- tpl (index .Values.fpm.templates "php.ini") . | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: {{ template "php.fullname" . }}-fpm-php-fpm-conf
   labels:
     app: {{ template "php.name" . }}

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -61,7 +61,7 @@ data:
 {{- $fpm := .Values.fpm -}}
 {{- if .Values.fpm.templates }}
 {{- range $name, $tmpl := .Values.fpm.templates }}
-{{- if and (ne $name "php-fpm.conf") (ne $name "php-fpm.d") }}
+{{- if and (ne $name "php-fpm.conf") (and (ne $name "php-fpm.d") (ne $name "php.ini")) }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    checksum/fpm-php-fpm-conf: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
+    checksum/fpm-phpini: {{ tpl (index .Values.fpm.templates "php.ini" | toYaml) . | sha256sum }}
 {{- with .Values.fpm.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -197,6 +197,9 @@ spec:
 {{- end }}
         - name: php-fpm-sock
           mountPath: /var/run/php-fpm
+        - name: phpini
+          subPath: php.ini
+          mountPath: /usr/local/etc/php/php.ini
         - name: fpm-conf
           subPath: php-fpm.conf
           mountPath: /usr/local/etc/php-fpm.conf
@@ -221,6 +224,9 @@ spec:
       - name: nginx-confd
         configMap:
           name: {{ template "php.fullname" . }}-nginx-conf-d
+      - name: phpini
+        configMap:
+          name: {{ template "php.fullname" . }}-fpm-phpini
       - name: fpm-conf
         configMap:
           name: {{ template "php.fullname" . }}-fpm-php-fpm-conf

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -197,7 +197,7 @@ spec:
 {{- end }}
         - name: php-fpm-sock
           mountPath: /var/run/php-fpm
-        - name: phpini
+        - name: php-ini
           subPath: php.ini
           mountPath: /usr/local/etc/php/php.ini
         - name: fpm-conf
@@ -224,9 +224,9 @@ spec:
       - name: nginx-confd
         configMap:
           name: {{ template "php.fullname" . }}-nginx-conf-d
-      - name: phpini
+      - name: php-ini
         configMap:
-          name: {{ template "php.fullname" . }}-fpm-phpini
+          name: {{ template "php.fullname" . }}-fpm-php-ini
       - name: fpm-conf
         configMap:
           name: {{ template "php.fullname" . }}-fpm-php-fpm-conf

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -310,13 +310,6 @@ fpm:
     maxRequests: 500
   requestTerminateTimeout: 0
 
-  # php.ini configuration
-  # http://php.net/manual/en/errorfunc.configuration.php
-  ini:
-    displayErrors: false
-    errorReporting: E_ALL
-    exposePhp: false
-
   livenessProbe: {}
   readinessProbe: {}
   resources: {}
@@ -377,6 +370,97 @@ fpm:
   # configuration PHP-FPM templates
   # If you can not be satisfied with the default settings you can change the template.
   templates:
+    php.ini: |
+      [PHP]
+
+      ;;;;;;;;;;;;;;;;;;;
+      ; About php.ini   ;
+      ;;;;;;;;;;;;;;;;;;;
+      ; PHP's initialization file, generally called php.ini, is responsible for
+      ; configuring many of the aspects of PHP's behavior.
+
+      ; PHP attempts to find and load this configuration from a number of locations.
+      ; The following is a summary of its search order
+      ; 1. SAPI module specific location.
+      ; 2. The PHPRC environment variable. (As of PHP 5.2.0)
+      ; 3. A number of predefined registry keys on Windows (As of PHP 5.2.0)
+      ; 4. Current working directory (except CLI)
+      ; 5. The web server's directory (for SAPI modules), or directory of PHP
+      ; (otherwise in Windows)
+      ; 6. The directory from the --with-config-file-path compile time option, or the
+      ; Windows directory (C:\windows or C:\winnt)
+      ; See the PHP docs for more specific information.
+      ; http://php.net/configuration.file
+
+      ; The syntax of the file is extremely simple.  Whitespace and lines
+      ; beginning with a semicolon are silently ignored (as you probably guessed).
+      ; Section headers (e.g. [Foo]) are also silently ignored, even though
+      ; they might mean something in the future.
+
+      ; Directives following the section heading [PATH=/www/mysite] only
+      ; apply to PHP files in the /www/mysite directory.  Directives
+      ; following the section heading [HOST=www.example.com] only apply to
+      ; PHP files served from www.example.com.  Directives set in these
+      ; special sections cannot be overridden by user-defined INI files or
+      ; at runtime. Currently, [PATH=] and [HOST=] sections only work under
+      ; CGI/FastCGI.
+      ; http://php.net/ini.sections
+
+      ; Directives are specified using the following syntax
+      ; directive = value
+      ; Directive names are *case sensitive* - foo=bar is different from FOO=bar.
+      ; Directives are variables used to configure PHP or PHP extensions.
+      ; There is no name validation.  If PHP can't find an expected
+      ; directive because it is not set or is mistyped, a default value will be used.
+
+      ; The value can be a string, a number, a PHP constant (e.g. E_ALL or M_PI), one
+      ; of the INI constants (On, Off, True, False, Yes, No and None) or an expression
+      ; (e.g. E_ALL & ~E_NOTICE), a quoted string ("bar"), or a reference to a
+      ; previously set variable or directive (e.g. ${foo})
+
+      ; Expressions in the INI file are limited to bitwise operators and parentheses
+      ; |  bitwise OR
+      ; ^  bitwise XOR
+      ; &  bitwise AND
+      ; ~  bitwise NOT
+      ; !  boolean NOT
+
+      ; Boolean flags can be turned on using the values 1, On, True or Yes.
+      ; They can be turned off using the values 0, Off, False or No.
+
+      ; An empty string can be denoted by simply not writing anything after the equal
+      ; sign, or by using the None keyword
+
+      ;  foo =         ; sets foo to an empty string
+      ;  foo = None    ; sets foo to an empty string
+      ;  foo = "None"  ; sets foo to the string 'None'
+
+      ; If you use constants in your value, and these constants belong to a
+      ; dynamically loaded extension (either a PHP extension or a Zend extension),
+      ; you may only use these constants *after* the line that loads the extension.
+
+      ;;;;;;;;;;;;;;;;;;;
+      ; About this file ;
+      ;;;;;;;;;;;;;;;;;;;
+      ; PHP comes packaged with two INI files. One that is recommended to be used
+      ; in production environments and one that is recommended to be used in
+      ; development environments.
+
+      ; php.ini-production contains settings which hold security, performance and
+      ; best practices at its core. But please be aware, these settings may break
+      ; compatibility with older or less security conscience applications. We
+      ; recommending using the production ini in production and testing environments.
+
+      ; php.ini-development is very similar to its production variant, except it is
+      ; much more verbose when it comes to errors. We recommend using the
+      ; development version only in development environments, as errors shown to
+      ; application users can inadvertently leak otherwise secure information.
+
+      ; This is php.ini-production INI file.
+
+      display_errors = Off
+      error_reporting = E_ALL
+      expose_php = Off
     php-fpm.conf: |
       ;;;;;;;;;;;;;;;;;;;;;
       ; FPM Configuration ;
@@ -930,17 +1014,6 @@ fpm:
         ;php_admin_value[memory_limit] = 32M
         php_admin_value[error_log] = /dev/stderr
         php_admin_flag[log_errors] = on
-        {{- range $k, $v := .Values.fpm.ini }}
-        {{- if eq (printf "%t" $v) "true" }}
-        php_flag[{{ snakecase $k }}] = on
-        {{- else if eq (printf "%t" $v) "false" }}
-        php_flag[{{ snakecase $k }}] = off
-        {{- else if eq (printf "%T" $v) "string" }}
-        php_value[{{ snakecase $k }}] = "{{ $v }}"
-        {{- else }}
-        php_value[{{ snakecase $k }}] = {{ $v }}
-        {{- end }}
-        {{- end }}
 
   # Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets`.
   annotations: {}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -1029,17 +1029,6 @@ fpm:
         ;php_admin_value[memory_limit] = 32M
         php_admin_value[error_log] = /dev/stderr
         php_admin_flag[log_errors] = on
-        {{- range $k, $v := .Values.fpm.ini }}
-        {{- if eq (printf "%t" $v) "true" }}
-        php_flag[{{ snakecase $k }}] = on
-        {{- else if eq (printf "%t" $v) "false" }}
-        php_flag[{{ snakecase $k }}] = off
-        {{- else if eq (printf "%T" $v) "string" }}
-        php_value[{{ snakecase $k }}] = "{{ $v }}"
-        {{- else }}
-        php_value[{{ snakecase $k }}] = {{ $v }}
-        {{- end }}
-        {{- end }}
 
   # Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets`.
   annotations: {}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -310,6 +310,10 @@ fpm:
     maxRequests: 500
   requestTerminateTimeout: 0
 
+  # php.ini configuration
+  # http://php.net/manual/en/errorfunc.configuration.php
+  ini: {}
+
   livenessProbe: {}
   readinessProbe: {}
   resources: {}
@@ -1014,6 +1018,17 @@ fpm:
         ;php_admin_value[memory_limit] = 32M
         php_admin_value[error_log] = /dev/stderr
         php_admin_flag[log_errors] = on
+        {{- range $k, $v := .Values.fpm.ini }}
+        {{- if eq (printf "%t" $v) "true" }}
+        php_flag[{{ snakecase $k }}] = on
+        {{- else if eq (printf "%t" $v) "false" }}
+        php_flag[{{ snakecase $k }}] = off
+        {{- else if eq (printf "%T" $v) "string" }}
+        php_value[{{ snakecase $k }}] = "{{ $v }}"
+        {{- else }}
+        php_value[{{ snakecase $k }}] = {{ $v }}
+        {{- end }}
+        {{- end }}
 
   # Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets`.
   annotations: {}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -312,7 +312,10 @@ fpm:
 
   # php.ini configuration
   # http://php.net/manual/en/errorfunc.configuration.php
-  ini: {}
+  ini:
+    displayErrors: false
+    errorReporting: E_ALL
+    exposePhp: false
 
   livenessProbe: {}
   readinessProbe: {}
@@ -462,9 +465,17 @@ fpm:
 
       ; This is php.ini-production INI file.
 
-      display_errors = Off
-      error_reporting = E_ALL
-      expose_php = Off
+      {{- range $k, $v := .Values.fpm.ini }}
+      {{- if eq (printf "%t" $v) "true" }}
+      {{ snakecase $k }} = On
+      {{- else if eq (printf "%t" $v) "false" }}
+      {{ snakecase $k }} = Off
+      {{- else if eq (printf "%T" $v) "string" }}
+      {{ snakecase $k }} = "{{ $v }}"
+      {{- else }}
+      {{ snakecase $k }} = {{ $v }}
+      {{- end }}
+      {{- end }}
     php-fpm.conf: |
       ;;;;;;;;;;;;;;;;;;;;;
       ; FPM Configuration ;

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -376,7 +376,6 @@ fpm:
   templates:
     php.ini: |
       [PHP]
-
       ;;;;;;;;;;;;;;;;;;;
       ; About php.ini   ;
       ;;;;;;;;;;;;;;;;;;;

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -312,10 +312,10 @@ fpm:
 
   # php.ini configuration
   # http://php.net/manual/en/errorfunc.configuration.php
-  ini:
-    displayErrors: false
-    errorReporting: E_ALL
-    exposePhp: false
+  ini: |
+    display_errors = Off
+    error_reporting = E_ALL
+    expose_php = Off
 
   livenessProbe: {}
   readinessProbe: {}
@@ -377,105 +377,6 @@ fpm:
   # configuration PHP-FPM templates
   # If you can not be satisfied with the default settings you can change the template.
   templates:
-    php.ini: |
-      [PHP]
-
-      ;;;;;;;;;;;;;;;;;;;
-      ; About php.ini   ;
-      ;;;;;;;;;;;;;;;;;;;
-      ; PHP's initialization file, generally called php.ini, is responsible for
-      ; configuring many of the aspects of PHP's behavior.
-
-      ; PHP attempts to find and load this configuration from a number of locations.
-      ; The following is a summary of its search order
-      ; 1. SAPI module specific location.
-      ; 2. The PHPRC environment variable. (As of PHP 5.2.0)
-      ; 3. A number of predefined registry keys on Windows (As of PHP 5.2.0)
-      ; 4. Current working directory (except CLI)
-      ; 5. The web server's directory (for SAPI modules), or directory of PHP
-      ; (otherwise in Windows)
-      ; 6. The directory from the --with-config-file-path compile time option, or the
-      ; Windows directory (C:\windows or C:\winnt)
-      ; See the PHP docs for more specific information.
-      ; http://php.net/configuration.file
-
-      ; The syntax of the file is extremely simple.  Whitespace and lines
-      ; beginning with a semicolon are silently ignored (as you probably guessed).
-      ; Section headers (e.g. [Foo]) are also silently ignored, even though
-      ; they might mean something in the future.
-
-      ; Directives following the section heading [PATH=/www/mysite] only
-      ; apply to PHP files in the /www/mysite directory.  Directives
-      ; following the section heading [HOST=www.example.com] only apply to
-      ; PHP files served from www.example.com.  Directives set in these
-      ; special sections cannot be overridden by user-defined INI files or
-      ; at runtime. Currently, [PATH=] and [HOST=] sections only work under
-      ; CGI/FastCGI.
-      ; http://php.net/ini.sections
-
-      ; Directives are specified using the following syntax
-      ; directive = value
-      ; Directive names are *case sensitive* - foo=bar is different from FOO=bar.
-      ; Directives are variables used to configure PHP or PHP extensions.
-      ; There is no name validation.  If PHP can't find an expected
-      ; directive because it is not set or is mistyped, a default value will be used.
-
-      ; The value can be a string, a number, a PHP constant (e.g. E_ALL or M_PI), one
-      ; of the INI constants (On, Off, True, False, Yes, No and None) or an expression
-      ; (e.g. E_ALL & ~E_NOTICE), a quoted string ("bar"), or a reference to a
-      ; previously set variable or directive (e.g. ${foo})
-
-      ; Expressions in the INI file are limited to bitwise operators and parentheses
-      ; |  bitwise OR
-      ; ^  bitwise XOR
-      ; &  bitwise AND
-      ; ~  bitwise NOT
-      ; !  boolean NOT
-
-      ; Boolean flags can be turned on using the values 1, On, True or Yes.
-      ; They can be turned off using the values 0, Off, False or No.
-
-      ; An empty string can be denoted by simply not writing anything after the equal
-      ; sign, or by using the None keyword
-
-      ;  foo =         ; sets foo to an empty string
-      ;  foo = None    ; sets foo to an empty string
-      ;  foo = "None"  ; sets foo to the string 'None'
-
-      ; If you use constants in your value, and these constants belong to a
-      ; dynamically loaded extension (either a PHP extension or a Zend extension),
-      ; you may only use these constants *after* the line that loads the extension.
-
-      ;;;;;;;;;;;;;;;;;;;
-      ; About this file ;
-      ;;;;;;;;;;;;;;;;;;;
-      ; PHP comes packaged with two INI files. One that is recommended to be used
-      ; in production environments and one that is recommended to be used in
-      ; development environments.
-
-      ; php.ini-production contains settings which hold security, performance and
-      ; best practices at its core. But please be aware, these settings may break
-      ; compatibility with older or less security conscience applications. We
-      ; recommending using the production ini in production and testing environments.
-
-      ; php.ini-development is very similar to its production variant, except it is
-      ; much more verbose when it comes to errors. We recommend using the
-      ; development version only in development environments, as errors shown to
-      ; application users can inadvertently leak otherwise secure information.
-
-      ; This is php.ini-production INI file.
-
-      {{- range $k, $v := .Values.fpm.ini }}
-      {{- if eq (printf "%t" $v) "true" }}
-      {{ snakecase $k }} = On
-      {{- else if eq (printf "%t" $v) "false" }}
-      {{ snakecase $k }} = Off
-      {{- else if eq (printf "%T" $v) "string" }}
-      {{ snakecase $k }} = "{{ $v }}"
-      {{- else }}
-      {{ snakecase $k }} = {{ $v }}
-      {{- end }}
-      {{- end }}
     php-fpm.conf: |
       ;;;;;;;;;;;;;;;;;;;;;
       ; FPM Configuration ;

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -375,7 +375,6 @@ fpm:
   # If you can not be satisfied with the default settings you can change the template.
   templates:
     php.ini: |
-      [PHP]
       ;;;;;;;;;;;;;;;;;;;
       ; About php.ini   ;
       ;;;;;;;;;;;;;;;;;;;

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -375,6 +375,8 @@ fpm:
   # If you can not be satisfied with the default settings you can change the template.
   templates:
     php.ini: |
+      [PHP]
+
       ;;;;;;;;;;;;;;;;;;;
       ; About php.ini   ;
       ;;;;;;;;;;;;;;;;;;;

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -310,13 +310,6 @@ fpm:
     maxRequests: 500
   requestTerminateTimeout: 0
 
-  # php.ini configuration
-  # http://php.net/manual/en/errorfunc.configuration.php
-  ini: |
-    display_errors = Off
-    error_reporting = E_ALL
-    expose_php = Off
-
   livenessProbe: {}
   readinessProbe: {}
   resources: {}
@@ -377,6 +370,97 @@ fpm:
   # configuration PHP-FPM templates
   # If you can not be satisfied with the default settings you can change the template.
   templates:
+    php.ini: |
+      [PHP]
+
+      ;;;;;;;;;;;;;;;;;;;
+      ; About php.ini   ;
+      ;;;;;;;;;;;;;;;;;;;
+      ; PHP's initialization file, generally called php.ini, is responsible for
+      ; configuring many of the aspects of PHP's behavior.
+
+      ; PHP attempts to find and load this configuration from a number of locations.
+      ; The following is a summary of its search order
+      ; 1. SAPI module specific location.
+      ; 2. The PHPRC environment variable. (As of PHP 5.2.0)
+      ; 3. A number of predefined registry keys on Windows (As of PHP 5.2.0)
+      ; 4. Current working directory (except CLI)
+      ; 5. The web server's directory (for SAPI modules), or directory of PHP
+      ; (otherwise in Windows)
+      ; 6. The directory from the --with-config-file-path compile time option, or the
+      ; Windows directory (C:\windows or C:\winnt)
+      ; See the PHP docs for more specific information.
+      ; http://php.net/configuration.file
+
+      ; The syntax of the file is extremely simple.  Whitespace and lines
+      ; beginning with a semicolon are silently ignored (as you probably guessed).
+      ; Section headers (e.g. [Foo]) are also silently ignored, even though
+      ; they might mean something in the future.
+
+      ; Directives following the section heading [PATH=/www/mysite] only
+      ; apply to PHP files in the /www/mysite directory.  Directives
+      ; following the section heading [HOST=www.example.com] only apply to
+      ; PHP files served from www.example.com.  Directives set in these
+      ; special sections cannot be overridden by user-defined INI files or
+      ; at runtime. Currently, [PATH=] and [HOST=] sections only work under
+      ; CGI/FastCGI.
+      ; http://php.net/ini.sections
+
+      ; Directives are specified using the following syntax
+      ; directive = value
+      ; Directive names are *case sensitive* - foo=bar is different from FOO=bar.
+      ; Directives are variables used to configure PHP or PHP extensions.
+      ; There is no name validation.  If PHP can't find an expected
+      ; directive because it is not set or is mistyped, a default value will be used.
+
+      ; The value can be a string, a number, a PHP constant (e.g. E_ALL or M_PI), one
+      ; of the INI constants (On, Off, True, False, Yes, No and None) or an expression
+      ; (e.g. E_ALL & ~E_NOTICE), a quoted string ("bar"), or a reference to a
+      ; previously set variable or directive (e.g. ${foo})
+
+      ; Expressions in the INI file are limited to bitwise operators and parentheses
+      ; |  bitwise OR
+      ; ^  bitwise XOR
+      ; &  bitwise AND
+      ; ~  bitwise NOT
+      ; !  boolean NOT
+
+      ; Boolean flags can be turned on using the values 1, On, True or Yes.
+      ; They can be turned off using the values 0, Off, False or No.
+
+      ; An empty string can be denoted by simply not writing anything after the equal
+      ; sign, or by using the None keyword
+
+      ;  foo =         ; sets foo to an empty string
+      ;  foo = None    ; sets foo to an empty string
+      ;  foo = "None"  ; sets foo to the string 'None'
+
+      ; If you use constants in your value, and these constants belong to a
+      ; dynamically loaded extension (either a PHP extension or a Zend extension),
+      ; you may only use these constants *after* the line that loads the extension.
+
+      ;;;;;;;;;;;;;;;;;;;
+      ; About this file ;
+      ;;;;;;;;;;;;;;;;;;;
+      ; PHP comes packaged with two INI files. One that is recommended to be used
+      ; in production environments and one that is recommended to be used in
+      ; development environments.
+
+      ; php.ini-production contains settings which hold security, performance and
+      ; best practices at its core. But please be aware, these settings may break
+      ; compatibility with older or less security conscience applications. We
+      ; recommending using the production ini in production and testing environments.
+
+      ; php.ini-development is very similar to its production variant, except it is
+      ; much more verbose when it comes to errors. We recommend using the
+      ; development version only in development environments, as errors shown to
+      ; application users can inadvertently leak otherwise secure information.
+
+      ; This is php.ini-production INI file.
+
+      display_errors = Off
+      error_reporting = E_ALL
+      expose_php = Off
     php-fpm.conf: |
       ;;;;;;;;;;;;;;;;;;;;;
       ; FPM Configuration ;


### PR DESCRIPTION
`php.ini` was made because PHP error is not output to standard error output.

Only the following items are set.
- display_errors
- error_reporting
- expose_php

If you want to add other items, add them to `.values.fpm.ini`. And they are added to `php.ini`

## before
The PHP chart did not show any PHP errors to logs.
```
helm install php .
kubectl exec php-949b58d77-2kw6m -c php-fpm  -- sh -c "echo \"<?php\na();\" > /var/www/html/error.php"
kubectl exec -it php-949b58d77-2kw6m -c php-fpm /bin/sh
/var/www/html # curl http://localhost/error.php

kubectl logs php-949b58d77-2kw6m -c php-fpm
[20-Nov-2019 06:30:54] NOTICE: fpm is running, pid 1
[20-Nov-2019 06:30:54] NOTICE: ready to handle connections
```

## after
This PR resolved it.
```
helm install php .
kubectl exec php-6c4fb59864-p2dtk -c php-fpm  -- sh -c "echo \"<?php\na();\" > /var/www/html/error.php"
kubectl exec -it php-6c4fb59864-p2dtk -c php-fpm /bin/sh
/var/www/html # curl http://localhost/error.php

kubectl logs php-6c4fb59864-p2dtk -c php-fpm
[20-Nov-2019 06:54:47] NOTICE: fpm is running, pid 1
[20-Nov-2019 06:54:47] NOTICE: ready to handle connections
[20-Nov-2019 06:56:35] WARNING: [pool www] child 11 said into stderr: "NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function php\na() in /var/www/html/error.php:1"
[20-Nov-2019 06:56:35] WARNING: [pool www] child 11 said into stderr: "Stack trace:"
[20-Nov-2019 06:56:35] WARNING: [pool www] child 11 said into stderr: "#0 {main}"
[20-Nov-2019 06:56:35] WARNING: [pool www] child 11 said into stderr: "  thrown in /var/www/html/error.php on line 1"
```
