### PR TITLE
SRE-1226: twistlock chart

### DIFF
--- a/twistlock-console/Chart.yaml
+++ b/twistlock-console/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: twistlock-console
+version: "0.0.1"
+appVersion: "19.07.363"
+description: Chart for Twistlock Console
+home: https://www.twistlock.com/
+maintainers:
+  - name: Ryo Sakamoto
+    email: sakamoto@chatwork.com

--- a/twistlock-console/Makefile
+++ b/twistlock-console/Makefile
@@ -1,0 +1,14 @@
+.PHONY: apply
+apply:
+	@if ! kubectl get namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" >/dev/null 2>&1; then \
+		kubectl create namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)"; \
+	fi
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --dry-run --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) .;
+
+.PHONY: test
+test:
+	echo "no test"
+
+.PHONY: delete
+delete:
+	echo "no delete task"

--- a/twistlock-console/README.md
+++ b/twistlock-console/README.md
@@ -1,0 +1,79 @@
+## twistlock-console
+
+This chart for twistlock-console https://www.twistlock.com/
+
+## TL;DR;
+
+You need follow parameters.
+
+- accessToken
+  - payout from twistlock
+
+```
+$ helm install --name twistlock-console --namespace twistlock --set accessToken="XXX" chatwork/twistlock-defender
+```
+
+## Prerequisites
+
+* Kubernetes 1.11+
+
+# Uninstalling the Chart
+
+```
+$ helm delete twistlock-console
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the gaurd chart and their default values.
+
+|  Parameter | Description | Default |
+| --- | --- | --- |
+|  `accessToken` | Payout from twistlock | `"accessToken"` |
+|  `image.imagePullSecrets` | Image imagePullSecrets | `"[]"` |
+|  `image.repository` | Defender image repository | `"registry-auth.twistlock.com/tw_{{ .Values.accessToken }}/twistlock/defender"` |
+|  `image.tag` | Defender image tag | `"defender{{ .Values.config.docker.tag }}"` |
+|  `image.imagePullPolicy` | Image pullpolicy  | `"IfNotPresent"` |
+|  `port.communication` | Console <-> Defener commutation port  | `"8084"` |
+|  `port.management.http` | Console management http port  | `"8081"` |
+|  `port.management.https` | Console management https port  | `"8083"` |
+|  `port.highAvailability` | Console high availability port  | `"8086"` |
+|  `volumeMounts.data.mountPath` | VolumeMounts path for data directory | `"/var/lib/twistlock"` |
+|  `volumeMounts.data.subPath` | VolumeMounts subPath for data directory | `"twistlock"` |
+|  `volumeMounts.backup.mountPath` | VolumeMounts path for backup directory | `"/var/lib/twistlock-backup"` |
+|  `volumeMounts.backup.subPath` | VolumeMounts subPath for backup directory | `"twistlock-backup"` |
+|  `config.console.cn` | Configuration console common name | `""` |
+|  `config.console.san` | Configuration console subject alternative name | `""` |
+|  `config.console.portalServer.cert` | Configuration console https custom cert | `""` |
+|  `config.console.portalServer.key` | Configuration console https custom key| `""` |
+|  `config.defender.cn` | Configuration defender common name | `""` |
+|  `config.defender.listenerType` | Configuration defender listener type| `"none"` |
+|  `config.readOnlyFs` | Sets Twistlock containers' file-systems to read-only | `true` |
+|  `config.runConsoleAsRoot` | Run Twistlock Console processes as root (default, twistlock user account) | `false` |
+|  `config.docker.tag` | docker image tag| `"_19_07_363"` |
+|  `config.docker.socket` | docker socket path| `"/var/run/docker.sock"` |
+|  `config.backup` | Enable backup (but same volume) | `"true"` |
+|  `config.management.http.enabled` | Enable management http | `"false"` |
+|  `config.highAvailability.enabled` | Enable console high availability | `"false"` |
+|  `config.highAvailability.state` | Console high availability state | `"PRIMARY"` |
+|  `config.scap.enabled` | Enable console scap | `"false"` |
+|  `config.selinux.label` | Configure selinux label | `"disable"` |
+|  `resources.limit.cpu` | Resources cpu limit | `"500m"` |
+|  `resources.limit.memory` | Resources memory limit | `"1024Mi"` |
+|  `resources.requests.cpu` | Resources cpu requests | `"250m"` |
+|  `resources.requests.memory` | Resources memory limit | `"1024Mi"` |
+|  `deployment.annotations` | Deployment annotations | `"{}"`|
+|  `deployment.replicas` | Deployment replicas | `1`|
+|  `deployment.strategy` | Deployment update strategy | `"{}"`|
+|  `podAnnotations` | Pod annotations | `{}`|
+|  `tolerations` | Pod tolerations | `[]`|
+|  `extraEnv` | Pod extra environment value | `[]`|
+|  `extraVolumeMounts` | Pod extra volumeMounts | `[]`|
+|  `extraVolume` | Pod extra volume | `[]`|
+|  `persistenceVolumeClaim.storage.size` | PVC volume size | `"100G"` |
+|  `persistenceVolumeClaim.storage.className` | PVC volume class name| `"gp2"` |
+|  `persistenceVolumeClaim.selector` | PVC selector | `"{}"` |
+|  `service.clusterIP` | Set service cluster ip | `""` |
+|  `service.type` | Set service type | `"LoadBalancer"` |
+|  `secrets` | Configuration secrets value | `"{}"` |
+|  `configmap.twistlock.cfg` | Configuration twistlock console using configmap | `"..."`|

--- a/twistlock-console/templates/_helpers.tpl
+++ b/twistlock-console/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "twistlock-console.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "twistlock-console.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "twistlock-console" .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/twistlock-console/templates/configmap.yaml
+++ b/twistlock-console/templates/configmap.yaml
@@ -3,5 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "twistlock-console.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
 data:
 {{ tpl (toYaml .Values.configmap) $root | indent 2 }}

--- a/twistlock-console/templates/configmap.yaml
+++ b/twistlock-console/templates/configmap.yaml
@@ -1,0 +1,7 @@
+{{ $root := . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "twistlock-console.fullname" $root }}
+data:
+{{ tpl (toYaml .Values.configmap) $root | indent 2 }}

--- a/twistlock-console/templates/deployment.yaml
+++ b/twistlock-console/templates/deployment.yaml
@@ -1,0 +1,126 @@
+{{ $root := . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "twistlock-console.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  {{- range $key, $value := .Values.deployment.annotations }}
+  annotations:
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+       app: {{ include "twistlock-console.fullname" $root }}
+       release: {{ .Release.Name }}
+  {{- with .Values.deployment.strategy }}
+  strategy:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "twistlock-console.fullname" $root }}
+        release: {{ .Release.Name }}
+      name: {{ template "twistlock-console.fullname" $root }}
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.configmap) . | sha256sum | quote }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "twistlock-console.fullname" $root }}
+      containers:
+      - name: twistlock-console
+        image: {{ tpl .Values.image.repository $root }}:{{ tpl .Values.image.tag $root }}
+        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        ports:
+        - name: mgmt-https
+          containerPort: {{ .Values.port.management.https }}
+        {{- if .Values.config.management.http.enabled }}
+        - name: mgmt-http
+          containerPort: {{ .Values.port.management.http }}
+        {{- end }}
+        - name: communication
+          containerPort: {{ .Values.port.communication }}
+        {{- if .Values.config.highAvailability.enabled }}
+        - name: ha
+          containerPort: {{ .Values.port.highAvailability }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 8 }}
+        env:
+        - name: CONFIG_PATH
+          value: /data/config/twistlock.cfg
+        - name: LOG_PROD
+          value: "true"
+        {{- if .Values.config.console.portalServer.key }}
+        - name: CONSOLE_PORTAL_SERVER_CERT
+          value: "{{ .Values.config.console.portalServer.cert }}"
+        - name: CONSOLE_PORTAL_SERVER_KEY
+          value: "{{ .Values.config.console.portalServer.key }}"
+        {{- end }}
+        {{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext:
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: twistlock-config-volume
+          mountPath: "/data/config/"
+        - name: persistent-volume
+          mountPath: "{{ .Values.volumeMounts.data.mountPath }}"
+          subPath: "{{ .Values.volumeMounts.data.subpath }}"
+        {{- if .Values.config.backup.enabled }}
+        - name: persistent-volume
+          mountPath: "{{ .Values.volumeMounts.backup.mountPath }}"
+          subPath: "{{ .Values.volumeMounts.backup.subpath }}"
+        {{- end}}
+        {{- if .Values.secrets }}
+        - name: portal-secrets-volume
+          mountPath: "/var/lib/twistlock/secrets"
+          readOnly: true
+        {{- end}}
+        - name: syslog-socket
+          mountPath: "/dev/log"
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ tpl (toYaml .) $root | indent 8 }}
+      {{- end }}
+      tolerations:
+      {{- with .Values.tolerations }}
+{{ tpl (toYaml .) | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: persistent-volume
+        persistentVolumeClaim:
+          claimName: {{ template "twistlock-console.fullname" $root }}
+      - name: syslog-socket
+        hostPath:
+          path: "/dev/log"
+      - name: twistlock-config-volume
+        configMap:
+          name: {{ template "twistlock-console.fullname" $root }}
+      {{- if .Values.secrets }}
+      - name: portal-secrets-volume
+        secret:
+          secretName: {{ template "twistlock-console.fullname" $root }}
+          defaultMode: 256
+      {{- end}}
+      {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
+      {{- end }}

--- a/twistlock-console/templates/deployment.yaml
+++ b/twistlock-console/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     release: {{ .Release.Name | quote }}
   {{- range $key, $value := .Values.deployment.annotations }}
   annotations:
-    {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ tpl $value $root | quote }}
   {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
@@ -31,7 +31,7 @@ spec:
       annotations:
         checksum/config: {{ tpl (toYaml .Values.configmap) . | sha256sum | quote }}
         {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ tpl $value $root | quote }}
         {{- end }}
     spec:
       {{- with .Values.image.imagePullSecrets }}
@@ -82,10 +82,10 @@ spec:
         - name: persistent-volume
           mountPath: "{{ .Values.volumeMounts.data.mountPath }}"
           subPath: "{{ .Values.volumeMounts.data.subpath }}"
-        {{- if .Values.config.backup.enabled }}
+        {{- if .Values.config.recovery.enabled }}
         - name: persistent-volume
-          mountPath: "{{ .Values.volumeMounts.backup.mountPath }}"
-          subPath: "{{ .Values.volumeMounts.backup.subpath }}"
+          mountPath: "{{ .Values.volumeMounts.recovery.mountPath }}"
+          subPath: "{{ .Values.volumeMounts.recovery.subpath }}"
         {{- end}}
         {{- if .Values.secrets }}
         - name: portal-secrets-volume

--- a/twistlock-console/templates/ingress.yaml
+++ b/twistlock-console/templates/ingress.yaml
@@ -1,0 +1,25 @@
+{{- $root := . -}}
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "twistlock-console.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  {{- range $key, $value := .Values.ingress.annotations }}
+  annotations:
+    {{ $key }}: {{ tpl $value $root | quote }}
+  {{- end }}
+spec:
+{{- with .Values.ingress.tls }}
+  tls:
+{{ tpl (toYaml .) $root | indent 2 }}
+{{- end }}
+  rules:
+{{- with .Values.ingress.rules }}
+{{ tpl (toYaml .) $root | indent 2 }}
+{{- end }}
+{{- end }}

--- a/twistlock-console/templates/persistentvolumeclaim.yaml
+++ b/twistlock-console/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+{{ $root := . }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "twistlock-console.fullname" $root }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolumeClaim.storage.size }}
+  storageClassName: {{ .Values.persistentVolumeClaim.storage.className }}
+  {{- with .Values.persistentVolumeClaim.selector }}
+  selector:
+{{ tpl (toYaml .) $root | indent 4 }}
+  {{- end }}

--- a/twistlock-console/templates/persistentvolumeclaim.yaml
+++ b/twistlock-console/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "twistlock-console.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/twistlock-console/templates/secrets.yaml
+++ b/twistlock-console/templates/secrets.yaml
@@ -4,6 +4,11 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "twistlock-console.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
 type: Opaque
 data:
 {{- with .Values.secrets }}

--- a/twistlock-console/templates/secrets.yaml
+++ b/twistlock-console/templates/secrets.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secrets }}
+{{ $root := . }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "twistlock-console.fullname" $root }}
+type: Opaque
+data:
+{{- with .Values.secrets }}
+{{ tpl (toYaml .) $root | indent 4 }}
+{{- end }}
+{{- end}}

--- a/twistlock-console/templates/service.yaml
+++ b/twistlock-console/templates/service.yaml
@@ -1,0 +1,29 @@
+{{ $root := . }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    release: {{ .Release.Name }}
+  name: {{ template "twistlock-console.fullname" $root }}
+spec:
+  {{- if and .Values.service.clusterIP (eq "ClusterIP" .Values.service.type) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end}}
+  type: {{ .Values.service.type }}
+  ports:
+  - name: communication
+    port: {{ .Values.port.communication }}
+  - name: mgmt-https
+    port: {{ .Values.port.management.https }}
+  {{- if .Values.config.management.http.enabled }}
+  - name: mgmt-http
+    port: {{ .Values.port.management.http }}
+  {{- end}}
+  {{- if .Values.config.highAvailability.enabled }}
+  - name: ha
+    port: {{ .Values.port.highAvailability }}
+  {{- end}}
+  selector:
+    app: {{ template "twistlock-console.fullname" $root }}
+    release: {{ .Release.Name }}

--- a/twistlock-console/templates/service.yaml
+++ b/twistlock-console/templates/service.yaml
@@ -4,9 +4,19 @@ kind: Service
 metadata:
   labels:
     app: {{ template "twistlock-console.fullname" $root }}
-    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
   name: {{ template "twistlock-console.fullname" $root }}
+  {{- range $key, $value := .Values.service.annotations }}
+  annotations:
+    {{ $key }}: {{ tpl $value $root | quote }}
+  {{- end }}
 spec:
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml . | indent 2 }}
+  {{- end }}
   {{- if and .Values.service.clusterIP (eq "ClusterIP" .Values.service.type) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end}}

--- a/twistlock-console/templates/serviceaccount.yaml
+++ b/twistlock-console/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "twistlock-console.fullname" . }}

--- a/twistlock-console/templates/serviceaccount.yaml
+++ b/twistlock-console/templates/serviceaccount.yaml
@@ -1,4 +1,14 @@
+{{ $root := . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "twistlock-console.fullname" . }}
+  labels:
+    app: {{ template "twistlock-console.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  {{- range $key, $value := .Values.serviceAccount.annotations }}
+  annotations:
+    {{ $key }}: {{ tpl $value $root | quote }}
+  {{- end }}

--- a/twistlock-console/twistlock.org.cfg
+++ b/twistlock-console/twistlock.org.cfg
@@ -1,0 +1,98 @@
+#  _____          _     _   _            _
+# |_   _|_      _(_)___| |_| | ___   ___| | __
+#   | | \ \ /\ / / / __| __| |/ _ \ / __| |/ /
+#   | |  \ V  V /| \__ \ |_| | (_) | (__|   <
+#   |_|   \_/\_/ |_|___/\__|_|\___/ \___|_|\_\\
+
+# This configuration file contains the setup parameters for Twistlock
+# This file is typically stored in the same directory as the installation script (twistlock.sh)
+# To reconfigure settings, update this configuration file and re-run twistlock.sh; state and unchanged settings will persist
+
+
+
+#############################################
+#     Network configuration
+#############################################
+# Each port must be set to a unique value (multiple services cannot share the same port)
+###### Management Console ports #####
+# Sets the ports that the Twistlock management website listens on
+# The system that you use to configure Twistlock must be able to connect to the Twistlock Console on these ports
+# To disable the HTTP listener, leave the value empty (e.g. MANAGEMENT_PORT_HTTP=)
+MANAGEMENT_PORT_HTTP=${MANAGEMENT_PORT_HTTP-8081}
+MANAGEMENT_PORT_HTTPS=8083
+
+##### Inter-system communication port #####
+# Sets the port for communication between the Defender(s) and the Console
+COMMUNICATION_PORT=8084
+
+##### Certificate common names (optional) #####
+# Determines how to construct the CN in the Console's certificate
+# This value should not be modified unless instructed to by Twistlock Support
+CONSOLE_CN=$(hostname --fqdn 2>/dev/null); if [[ $? == 1 ]]; then CONSOLE_CN=$(hostname); fi
+# Determines how to construct the CN in the Defenders' certificates
+# Each Defender authenticates to the Console with this certificate and each cert must have a unique CN
+# These values should not be modified unless instructed to by Twistlock Support
+DEFENDER_CN=${DEFENDER_CN:-}
+
+#############################################
+#     Twistlock system configuration
+#############################################
+###### Data recovery #####
+# Data recovery automatically exports the full Twistlock configuration to the specified path every 24 hours
+# Daily, weekly, and monthly snapshots are retained
+# The exported configuration can be stored on durable storage or backed up remotely with other tools
+# Sets data recovery state (enabled or disabled)
+DATA_RECOVERY_ENABLED=true
+# Sets the directory to which Twistlock data is exported
+DATA_RECOVERY_VOLUME=/var/lib/twistlock-backup
+
+##### Read only containers #####
+# Sets Twistlock containers' file-systems to read-only
+READ_ONLY_FS=true
+
+##### Storage paths #####
+# Sets the base directory to store Twistlock local data (db and log files)
+DATA_FOLDER=/var/lib/twistlock
+
+##### Docker socket #####
+# Sets the location of the Docker socket file
+DOCKER_SOCKET=${DOCKER_SOCKET:-/var/run/docker.sock}
+# Sets the type of the Docker listener (TCP or NONE)
+DEFENDER_LISTENER_TYPE=${DEFENDER_LISTENER_TYPE:-NONE}
+
+#### SCAP (XCCDF) configuration ####
+# Sets SCAP state (enabled or disabled)
+SCAP_ENABLED=${SCAP_ENABLED:-false}
+
+#### systemd configuration ####
+# Installs Twistlock as systemd service
+SYSTEMD_ENABLED=${SYSTEMD_ENABLED:-false}
+
+#### userid configuration ####
+# Run Twistlock Console processes as root (default, twistlock user account)
+# Typically used to run Console on standard (tcp/443) privileged port for TLS
+RUN_CONSOLE_AS_ROOT=${RUN_CONSOLE_AS_ROOT:-false}
+
+#### SELinux configuration ####
+# If SELinux is enabled in dockerd, enable running Twistlock Console and Defender with a dedicated SELinux label
+# See https://docs.docker.com/engine/reference/run/#security-configuration
+SELINUX_LABEL=disable
+
+#############################################
+#      High availability settings
+#############################################
+# Only to be used when the Console is deployed outside of a Kubernetes cluster
+# This native HA capability uses Mongo clustering and requires 3 or more instances
+HIGH_AVAILABILITY_ENABLED=false
+HIGH_AVAILABILITY_STATE=PRIMARY
+HIGH_AVAILABILITY_PORT=8086
+
+
+
+#############################################
+#      Twistlock repository configuration
+#############################################
+# Sets the version tag of the Twistlock containers
+# Do not modify unless instructed to by Twistlock Support
+DOCKER_TWISTLOCK_TAG=_19_07_358
+

--- a/twistlock-console/values.yaml
+++ b/twistlock-console/values.yaml
@@ -1,0 +1,200 @@
+fullnameOverride: ""
+nameOverride: ""
+
+accessToken: "accessToken"
+
+image:
+  repository: registry-auth.twistlock.com/tw_{{ .Values.accessToken }}/twistlock/console
+  tag: console{{ .Values.config.docker.tag }}
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+port:
+  communication: "8084"
+  management:
+    http: "8081"
+    https: "8083"
+  highAvailability: "8086"
+
+volumeMounts:
+  data:
+    mountPath: "/var/lib/twistlock"
+    subpath: "twistlock"
+  backup:
+    # This value is default value, but backup path seems buggy and cannot be changed(@ 19_07)
+    mountPath: "/var/lib/twistlock-backup"
+    subpath: "twistlock-backup"
+
+config:
+  console:
+    # common name
+    cn: ""
+    # Subject Alternative Name
+    #san: "{{ .Release.Name }}"
+    san: ""
+    portalServer:
+      cert: ""
+      key: ""
+  defender:
+    cn: ""
+    listenerType: "none"
+  readOnlyFs:
+    enabled: true
+  runConsoleAsRoot:
+    enabled: false
+  docker:
+    tag: "_19_07_363"
+    socket: "/var/run/docker.sock"
+  backup:
+    enabled: true
+  management:
+    http:
+      enabled: true
+  highAvailability:
+    enabled: false
+    state: "PRIMARY"
+  scap:
+    enabled: false
+  selinux:
+    label: "disable"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 1024Mi
+  requests:
+    cpu: 250m
+    memory: 1024Mi
+
+deployment:
+  annotations: {}
+  replicas: 1
+  strategy: {}
+
+podAnnotations: {}
+tolerations: []
+extraEnv: []
+extraVolumeMounts: []
+extraVolumes: []
+
+persistentVolumeClaim:
+  storage:
+    size: 100Gi
+    className: "gp2" # for AWS
+  selector: {}
+
+service:
+  clusterIP: ""
+  type: "LoadBalancer"
+
+secrets: {}
+
+configmap:
+  twistlock.cfg: |
+    #  _____          _     _   _            _
+    # |_   _|_      _(_)___| |_| | ___   ___| | __
+    #   | | \ \ /\ / / / __| __| |/ _ \ / __| |/ /
+    #   | |  \ V  V /| \__ \ |_| | (_) | (__|   <
+    #   |_|   \_/\_/ |_|___/\__|_|\___/ \___|_|\_\\
+
+    # This configuration file contains the setup parameters for Twistlock
+    # This file is typically stored in the same directory as the installation script (twistlock.sh)
+    # To reconfigure settings, update this configuration file and re-run twistlock.sh; state and unchanged settings will persist
+
+
+
+    #############################################
+    #     Network configuration
+    #############################################
+    # Each port must be set to a unique value (multiple services cannot share the same port)
+    ###### Management Console ports #####
+    # Sets the ports that the Twistlock management website listens on
+    # The system that you use to configure Twistlock must be able to connect to the Twistlock Console on these ports
+    # To disable the HTTP listener, leave the value empty (e.g. MANAGEMENT_PORT_HTTP=)
+    {{- if .Values.config.management.http.enabled }}
+    MANAGEMENT_PORT_HTTP={{ .Values.port.management.http }}
+    {{- end }}
+    MANAGEMENT_PORT_HTTPS={{ .Values.port.management.https }}
+
+    ##### Inter-system communication port #####
+    # Sets the port for communication between the Defender(s) and the Console
+    COMMUNICATION_PORT={{ .Values.port.communication }}
+
+    ##### Certificate common names (optional) #####
+    # Determines how to construct the CN in the Console's certificate
+    # This value should not be modified unless instructed to by Twistlock Support
+    {{- if .Values.config.console.cn }}
+    CONSOLE_CN={{ tpl .Values.config.console.cn . }}
+    {{- else }}
+    CONSOLE_CN=$(hostname --fqdn 2>/dev/null); if [[ $? == 1 ]]; then CONSOLE_CN=$(hostname); fi
+    {{- end }}
+    # Determines how to construct the CN in the Defenders' certificates
+    # Each Defender authenticates to the Console with this certificate and each cert must have a unique CN
+    # These values should not be modified unless instructed to by Twistlock Support
+    {{- if .Values.config.defender.cn }}
+    DEFENDER_CN={{ tpl .Values.config.defender.cn . }}
+    {{- end }}
+
+    {{- if .Values.config.console.san }}
+    CONSOLE_SAN={{ tpl .Values.config.console.san . }}
+    {{- end }}
+
+    #############################################
+    #     Twistlock system configuration
+    #############################################
+    ###### Data recovery #####
+    # Data recovery automatically exports the full Twistlock configuration to the specified path every 24 hours
+    # Daily, weekly, and monthly snapshots are retained
+    # The exported configuration can be stored on durable storage or backed up remotely with other tools
+    # Sets data recovery state (enabled or disabled)
+    DATA_RECOVERY_ENABLED={{ .Values.config.backup.enabled }}
+    # Sets the directory to which Twistlock data is exported
+    DATA_RECOVERY_VOLUME={{ .Values.volumeMounts.backup.mountPath }}
+
+    ##### Read only containers #####
+    # Sets Twistlock containers' file-systems to read-only
+    READ_ONLY_FS={{ .Values.config.readOnlyFs.enabled }}
+
+    ##### Storage paths #####
+    # Sets the base directory to store Twistlock local data (db and log files)
+    DATA_FOLDER={{ .Values.volumeMounts.data.mountPath }}
+
+    ##### Docker socket #####
+    # Sets the location of the Docker socket file
+    DOCKER_SOCKET={{ .Values.config.docker.socket }}
+    # Sets the type of the Docker listener (TCP or NONE)
+    DEFENDER_LISTENER_TYPE={{ .Values.config.defender.listenerType }}
+
+    #### SCAP (XCCDF) configuration ####
+    # Sets SCAP state (true or false)
+    SCAP_ENABLED={{ .Values.config.scap.enabled }}
+
+    #### systemd configuration ####
+    # Installs Twistlock as systemd service
+    SYSTEMD_ENABLED=false
+
+    #### userid configuration ####
+    # Run Twistlock Console processes as root (default, twistlock user account)
+    # Typically used to run Console on standard (tcp/443) privileged port for TLS
+    RUN_CONSOLE_AS_ROOT={{ .Values.config.runConsoleAsRoot.enabled }}
+
+    #### SELinux configuration ####
+    # If SELinux is enabled in dockerd, enable running Twistlock Console and Defender with a dedicated SELinux label
+    # See https://docs.docker.com/engine/reference/run/#security-configuration
+    SELINUX_LABEL={{ .Values.config.selinux.label }}
+
+    #############################################
+    #      High availability settings
+    #############################################
+    # Only to be used when the Console is deployed outside of a Kubernetes cluster
+    # This native HA capability uses Mongo clustering and requires 3 or more instances
+    HIGH_AVAILABILITY_ENABLED={{ .Values.config.highAvailability.enabled }}
+    HIGH_AVAILABILITY_STATE={{ .Values.config.highAvailability.state }}
+    HIGH_AVAILABILITY_PORT={{ .Values.port.highAvailability }}
+
+    #############################################
+    #      Twistlock repository configuration
+    #############################################
+    # Sets the version tag of the Twistlock containers
+    # Do not modify unless instructed to by Twistlock Support
+    DOCKER_TWISTLOCK_TAG={{ .Values.config.docker.tag }}

--- a/twistlock-console/values.yaml
+++ b/twistlock-console/values.yaml
@@ -20,7 +20,7 @@ volumeMounts:
   data:
     mountPath: "/var/lib/twistlock"
     subpath: "twistlock"
-  backup:
+  recovery:
     # This value is default value, but backup path seems buggy and cannot be changed(@ 19_07)
     mountPath: "/var/lib/twistlock-backup"
     subpath: "twistlock-backup"
@@ -45,7 +45,7 @@ config:
   docker:
     tag: "_19_07_363"
     socket: "/var/run/docker.sock"
-  backup:
+  recovery:
     enabled: true
   management:
     http:
@@ -86,8 +86,19 @@ persistentVolumeClaim:
 service:
   clusterIP: ""
   type: "LoadBalancer"
+  annotations: {}
+  loadBalancerSourceRanges: []
+
+ingress:
+  enabled: false
+  annotations: {}
+  tls: []
+  rules: []
 
 secrets: {}
+
+serviceAccount:
+  annotations: {}
 
 configmap:
   twistlock.cfg: |
@@ -147,9 +158,9 @@ configmap:
     # Daily, weekly, and monthly snapshots are retained
     # The exported configuration can be stored on durable storage or backed up remotely with other tools
     # Sets data recovery state (enabled or disabled)
-    DATA_RECOVERY_ENABLED={{ .Values.config.backup.enabled }}
+    DATA_RECOVERY_ENABLED={{ .Values.config.recovery.enabled }}
     # Sets the directory to which Twistlock data is exported
-    DATA_RECOVERY_VOLUME={{ .Values.volumeMounts.backup.mountPath }}
+    DATA_RECOVERY_VOLUME={{ .Values.volumeMounts.recovery.mountPath }}
 
     ##### Read only containers #####
     # Sets Twistlock containers' file-systems to read-only

--- a/twistlock-defender/Chart.yaml
+++ b/twistlock-defender/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: twistlock-defender
+version: 0.0.1
+appVersion: "19.07.363"
+description: Chart for Twistlock Defender
+home: https://www.twistlock.com/
+maintainers:
+  - name: Ryo Sakamoto
+    email: sakamoto@chatwork.com

--- a/twistlock-defender/Makefile
+++ b/twistlock-defender/Makefile
@@ -1,0 +1,14 @@
+.PHONY: apply
+apply:
+	@if ! kubectl get namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" >/dev/null 2>&1; then \
+		kubectl create namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)"; \
+	fi
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --dry-run --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) .;
+
+.PHONY: test
+test:
+	echo "no test"
+
+.PHONY: delete
+delete:
+	echo "no delete task"

--- a/twistlock-defender/README.md
+++ b/twistlock-defender/README.md
@@ -1,0 +1,97 @@
+## twistlock-defender
+
+This chart for twistlock-defender https://www.twistlock.com/
+twistlock-defender is agent per node.
+
+## TL;DR;
+
+You need follow parameters.
+
+- accessToken
+  - payout from twistlock
+- config.clusterId 
+  - generate by twistcli export
+- secret.ca_cert
+  - generate by twistcli export
+- secret.client_cert
+  - generate by twistcli export
+- secret.client_key
+  - generate by twistcli export
+- secret.service_parameter
+  - generate by twistcli export
+
+The above parameters are difficult to specify with set option, so please write to file(ex. settings.yaml).
+
+```
+$ helm install -f settings.yaml --name twistlock-defender --namespace twistlock chatwork/twistlock-defender
+```
+
+## Prerequisites
+
+* Kubernetes 1.11+
+
+# Uninstalling the Chart
+
+```
+$ helm delete twistlock-defender
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the gaurd chart and their default values.
+
+|  Parameter | Description | Default |
+| --- | --- | --- |
+|  `accessToken` | Payout from twistlock | `"accessToken"` |
+|  `console.dnsName` | Console dnsName for communicate with defender | `"twistlock-console" `|
+|  `console.port` | Console port for communicate with defender | `"8084" `|
+|  `image.imagePullSecrets` | Image imagePullSecrets | `"[]"` |
+|  `image.repository` | Defender image repository | `"registry-auth.twistlock.com/tw_{{ .Values.accessToken }}/twistlock/defender"` |
+|  `image.tag` | Defender image tag | `"defender{{ .Values.config.docker.tag }}"` |
+|  `image.imagePullPolicy` | Image pullpolicy  | `"IfNotPresent"` |
+|  `volumeMounts.data` | VolumeMounts path for data directory | `"/var/lib/twistlock"` |
+|  `volumeMounts.certificates` | VolumeMounts path for certificates(secrets) | `"/var/lib/twistlock/certificates"` |
+|  `volumeMounts.docker.sockPath` | VolumeMounts path for docker sock root path | `"/var/run"` |
+|  `volumeMounts.docker.netns` | VolumeMounts path for docker netns(network namespace) | `"/var/run/docker/netns"` |
+|  `volumeMounts.iptablesFlockPath` | VolumeMounts path for iptables | `"/run"` |
+|  `volumes.data` | Host Path for data volume  | `"/var/lib/twistlock/defender"` |
+|  `volumes.docker.sockPath` | Host Path for docker sock root  | `"/var/run"` |
+|  `volumes.docker.netns` | Host Path for docker netns | `"/var/run/docker/netns"` |
+|  `volumes.iptablesFlockPath` | Host Path for iptables | `"/run"` |
+|  `volumes.passwd` | Host Path for passwd | `"/etc/passwd"` |
+|  `volumes.auditlog` | Host Path for auditd path | `"/var/log/audit"` |
+|  `volumes.syslog` | Host Path for syslog | `"/dev/log"` |
+|  `config.console.wsAddress` | Configuration twistlock-console web socket address | `"wss://{{ .Values.console.dnsName }}:{{ .Values.console.port }}"` |
+|  `config.defender.type` | Configuration defender type | `"daemonset"` |
+|  `config.defender.listenerType` | Configuration defender listener type | `"none"` |
+|  `config.clusterId` | Configuration defender clusterId which generate by console | `"%%CLUSTERID%%"` |
+|  `config.monitor.serviceAccounts` | Configuration monitor service accounts | `"true"` |
+|  `config.monitor.istio` | Configuration monitor istio | `"false"` |
+|  `config.installBundle` | Configuration installBundle for rasp | `""` |
+|  `config.docker.clientAddress` | Configuration docker client address path | `"/var/run/docker.sock"` |
+|  `config.docker.tag` | Configuration docker tag for image | `"_19_07_363"` |
+|  `resources.limit.cpu` | Resources cpu limit | `"1000m"` |
+|  `resources.limit.memory` | Resources memory limit | `"512Mi"` |
+|  `resources.requests.cpu` | Resources cpu requests | `"250m"` |
+|  `resources.requests.memory` | Resources memory limit | `"256Mi"` |
+|  `securityContext.readOnlyRootFileSystem` | Security Context for read only root | `"true"` |
+|  `securityContext.privileged` | Security Context for read privileged | `"true"` |
+|  `securityContext.capabilities.add` | Security Context for capabilities | `"[NET_ADMIN, SYS_ADMIN, SYS_PTRACE, AUDIT_CONTROL]"` |
+|  `secret.ca_cert` | ca cert for defender | `"%%CA_CERT%%"` |
+|  `secret.client_cert` | client cert for defender | `"%%CLIENT_CERT%%"` |
+|  `secret.client_key` | client key for defender | `"%%CLIENT_KEY%%"` |
+|  `secret.service_parameter` | service parameter which genrated by console for defender | `"%%SERVICE_PARAMETER%%"` |
+|  `useHostNetwork` | Pod using hostNetwork | `true`|
+|  `useHostPID` | Pod using hostPID | `true`|
+|  `deployment.enabled` | Enable defender deployment | `false`|
+|  `deployment.annotations` | Deployment annotations | `"{}"`|
+|  `deployment.replicas` | Deployment replicas | `1`|
+|  `deployment.strategy` | Deployment update strategy | `"{}"`|
+|  `daemonset.enabled` | Enable defender daemonset| `true`|
+|  `daemonset.annotations` | Damonset annotations | `"{}"`|
+|  `daemonset.updateStrategy` | Daemonset update strategy | `"{}"`|
+|  `podAnnotations` | Pod annotations | `{}`|
+|  `tolerations` | Pod tolerations | `[]`|
+|  `extraEnv` | Pod extra environment value | `[]`|
+|  `extraVolumeMounts` | Pod extra volumeMounts | `[]`|
+|  `extraVolume` | Pod extra volume | `[]`|

--- a/twistlock-defender/README.md
+++ b/twistlock-defender/README.md
@@ -9,7 +9,7 @@ You need follow parameters.
 
 - accessToken
   - payout from twistlock
-- config.clusterId 
+- config.clusterId
   - generate by twistcli export
 - secret.ca_cert
   - generate by twistcli export
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the gaurd chart and the
 |  `config.console.wsAddress` | Configuration twistlock-console web socket address | `"wss://{{ .Values.console.dnsName }}:{{ .Values.console.port }}"` |
 |  `config.defender.type` | Configuration defender type | `"daemonset"` |
 |  `config.defender.listenerType` | Configuration defender listener type | `"none"` |
-|  `config.clusterId` | Configuration defender clusterId which generate by console | `"%%CLUSTERID%%"` |
+|  `config.clusterId` | Configuration defender clusterId which generate by console | `"CLUSTERID"` |
 |  `config.monitor.serviceAccounts` | Configuration monitor service accounts | `"true"` |
 |  `config.monitor.istio` | Configuration monitor istio | `"false"` |
 |  `config.installBundle` | Configuration installBundle for rasp | `""` |
@@ -77,10 +77,10 @@ The following table lists the configurable parameters of the gaurd chart and the
 |  `securityContext.readOnlyRootFileSystem` | Security Context for read only root | `"true"` |
 |  `securityContext.privileged` | Security Context for read privileged | `"true"` |
 |  `securityContext.capabilities.add` | Security Context for capabilities | `"[NET_ADMIN, SYS_ADMIN, SYS_PTRACE, AUDIT_CONTROL]"` |
-|  `secret.ca_cert` | ca cert for defender | `"%%CA_CERT%%"` |
-|  `secret.client_cert` | client cert for defender | `"%%CLIENT_CERT%%"` |
-|  `secret.client_key` | client key for defender | `"%%CLIENT_KEY%%"` |
-|  `secret.service_parameter` | service parameter which genrated by console for defender | `"%%SERVICE_PARAMETER%%"` |
+|  `secret.ca_cert` | ca cert for defender | `"CA_CERT"` |
+|  `secret.client_cert` | client cert for defender | `"CLIENT_CERT"` |
+|  `secret.client_key` | client key for defender | `"CLIENT_KEY"` |
+|  `secret.service_parameter` | service parameter which genrated by console for defender | `"SERVICE_PARAMETER"` |
 |  `useHostNetwork` | Pod using hostNetwork | `true`|
 |  `useHostPID` | Pod using hostPID | `true`|
 |  `deployment.enabled` | Enable defender deployment | `false`|

--- a/twistlock-defender/templates/_helpers.tpl
+++ b/twistlock-defender/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "twistlock-defender.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "twistlock-defender.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "twistlock-defender" .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/twistlock-defender/templates/clusterrole.yaml
+++ b/twistlock-defender/templates/clusterrole.yaml
@@ -1,0 +1,28 @@
+{{- if or .Values.config.monitor.istio .Values.config.monitor.serviceAccounts }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "twistlock-defender.fullname" . }}
+  labels:
+    app: {{ template "twistlock-defender.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+rules:
+{{- if .Values.config.monitor.serviceAccounts }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"] # Allow Defenders to list RBAC resources
+  verbs: ["list"]
+{{- end}}
+{{- if .Values.config.monitor.istio }}
+- apiGroups: ["rbac.istio.io"]
+  resources: ["rbacconfigs", "servicerolebindings", "serviceroles"] # Allow Defenders to list Istio RBAC resources
+  verbs: ["list"]
+- apiGroups: ["authentication.istio.io"]
+  resources: ["meshpolicies"] # Allow Defenders to list Istio mesh policies
+  verbs: ["list"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["virtualservices", "destinationrules", "gateways", "serviceentries"] # Allow Defenders to list Istio networking resources
+  verbs: ["list"]
+{{- end}}
+{{- end}}

--- a/twistlock-defender/templates/clusterrolebinding.yaml
+++ b/twistlock-defender/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if or .Values.config.monitor.istio .Values.config.monitor.serviceAccounts }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "twistlock-defender.fullname" . }}
+  labels:
+    app: "{{ template "twistlock-defender.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "twistlock-defender.fullname" . }}
+subjects:
+- apiGroup:
+  kind: ServiceAccount
+  name: {{ template "twistlock-defender.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end}}

--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
       name: {{ template "twistlock-defender.fullname" $root }}
       annotations:
         checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum | quote }}
+        checksum/secret: {{ tpl (toYaml .Values.secret) . | sha256sum | quote }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -1,0 +1,152 @@
+{{- if and .Values.daemonset.enabled (not .Values.deployment.enabled) }}
+{{ $root := . }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "twistlock-defender.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-defender.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  {{- range $key, $value := .Values.daemonset.annotations }}
+  annotations:
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+       app: {{ template "twistlock-defender.fullname" $root }}
+       release: {{ .Release.Name }}
+  {{- with .Values.daemonset.updateStrategy }}
+  updateStrategy:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "twistlock-defender.fullname" $root }}
+        release: {{ .Release.Name }}
+      name: {{ template "twistlock-defender.fullname" $root }}
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum | quote }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- if or .Values.config.monitor.istio .Values.config.monitor.serviceAccounts }}
+      serviceAccountName: {{ template "twistlock-defender.fullname" $root }}
+      {{- end }}
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+      - name: twistlock-defender
+        image: {{ tpl .Values.image.repository $root }}:{{ tpl .Values.image.tag $root }}
+        env:
+        - name: LOG_PROD
+          value: "true"
+        - name: SYSTEMD_ENABLED
+          value: "false"
+        - name: WS_ADDRESS
+          value: "{{ tpl .Values.config.console.wsAddress $root }}"
+        - name: DEFENDER_TYPE
+          value: "daemonset"
+        - name: DEFENDER_LISTENER_TYPE
+          value: "{{ .Values.config.defender.listenerType }}"
+        - name: DOCKER_CLIENT_ADDRESS
+          value: "{{ .Values.config.docker.clientAddress }}"
+        - name: DEFENDER_CLUSTER_ID
+          value: "{{ .Values.config.clusterId }}"
+        - name: MONITOR_SERVICE_ACCOUNTS
+          value: "{{ .Values.config.monitor.serviceAccounts }}"
+        - name: MONITOR_ISTIO
+          value: "{{ .Values.config.monitor.istio }}"
+        - name: INSTALL_BUNDLE
+          value: "{{ .Values.config.installBundle }}"
+        {{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: host-root
+          mountPath: "/host"
+        - name: data-path
+          mountPath: "{{ .Values.volumeMounts.data }}"
+        - name: certificates
+          mountPath: "{{ .Values.volumeMounts.certificates }}"
+        - name: docker-sock-path
+          mountPath: "{{ .Values.volumeMounts.docker.sockPath }}"
+        - name: passwd
+          mountPath: "/etc/passwd"
+          readOnly: true
+        - name: docker-netns
+          mountPath: "{{ .Values.volumeMounts.docker.netns }}"
+          readOnly: true
+        - name: syslog-socket
+          mountPath: "/dev/log"
+        - name: auditd-log
+          mountPath: "/var/log/audit"
+        {{- if and .Values.volumes.iptablesFlockPath .Values.volumeMounts.iptablesFlockPath }}
+        - name: iptables-lock
+          mountPath: "{{ .Values.volumeMounts.iptablesFlockPath }}"
+        {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ tpl (toYaml .) $root | indent 8 }}
+      {{- end }}
+      tolerations:
+      {{- with .Values.tolerations }}
+{{ tpl (toYaml .) $root | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: data-path
+        hostPath:
+          path: "{{ .Values.volumes.data }}"
+      - name: certificates
+        secret:
+          secretName: {{ template "twistlock-defender.fullname" . }}
+          defaultMode: 256
+      - name: syslog-socket
+        hostPath:
+          path: "{{ .Values.volumes.syslog }}"
+      - name: host-root
+        hostPath:
+          path: "/"
+      - name: docker-sock-path
+        hostPath:
+          path: "{{ .Values.volumes.docker.sockPath }}"
+      - name: docker-netns
+        hostPath:
+          path: "{{ .Values.volumes.docker.netns }}"
+      - name: passwd
+        hostPath:
+          path: "{{ .Values.volumes.passwd }}"
+      - name: auditd-log
+        hostPath:
+          path: "{{ .Values.volumes.auditLog }}"
+      {{- if and .Values.volumes.iptablesFlockPath .Values.volumeMounts.iptablesFlockPath }}
+      - name: iptables-lock
+        hostPath:
+          path: "{{ .Values.volumes.iptablesFlockPath }}"
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
+      {{- end }}
+      {{- if .Values.useHostPID }}
+      hostPID: true
+      {{- end }}
+      {{- if .Values.useHostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+{{- end }}

--- a/twistlock-defender/templates/deployment.yaml
+++ b/twistlock-defender/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       name: {{ template "twistlock-defender.fullname" $root }}
       annotations:
         checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum | quote }}
+        checksum/secret: {{ tpl (toYaml .Values.secret) . | sha256sum | quote }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/twistlock-defender/templates/deployment.yaml
+++ b/twistlock-defender/templates/deployment.yaml
@@ -1,0 +1,165 @@
+{{- if and .Values.deployment.enabled (not .Values.daemonset.enabled) }}
+{{ $root := . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "twistlock-defender.fullname" $root }}
+  labels:
+    app: {{ template "twistlock-defender.fullname" $root }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  {{- range $key, $value := .Values.daemonset.annotations }}
+  annotations:
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+       app: {{ template "twistlock-defender.fullname" $root }}
+       release: {{ .Release.Name }}
+  {{- with .Values.deployment.strategy }}
+  strategy:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "twistlock-defender.fullname" $root }}
+        release: {{ .Release.Name }}
+      name: {{ template "twistlock-defender.fullname" $root }}
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum | quote }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- if or .Values.config.monitor.istio .Values.config.monitor.serviceAccounts }}
+      serviceAccountName: {{ template "twistlock-defender.fullname" $root }}
+      {{- end }}
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+      - name: twistlock-defender
+        image: {{ tpl .Values.image.repository $root }}:{{ tpl .Values.image.tag $root }}
+        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        volumeMounts:
+        - name: host-root
+          mountPath: "/host"
+        - name: data-path
+          mountPath: "{{ .Values.volumeMounts.data }}"
+        - name: certificates
+          mountPath: "{{ .Values.volumeMounts.certificates }}"
+        - name: docker-sock-path
+          mountPath: "{{ .Values.volumeMounts.docker.sockPath }}"
+        - name: passwd
+          mountPath: "/etc/passwd"
+          readOnly: true
+        - name: docker-netns
+          mountPath: "{{ .Values.volumeMounts.docker.netns }}"
+          readOnly: true
+        - name: syslog-socket
+          mountPath: "/dev/log"
+        - name: auditd-log
+          mountPath: "/var/log/audit"
+        {{- if and .Values.volumes.iptablesFlockPath .Values.volumeMounts.iptablesFlockPath }}
+        - name: iptables-lock
+          mountPath: "{{ .Values.volumeMounts.iptablesFlockPath }}"
+        {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        env:
+        - name: LOG_PROD
+          value: "true"
+        - name: SYSTEMD_ENABLED
+          value: "false"
+        - name: WS_ADDRESS
+          value: "{{ tpl .Values.config.console.wsAddress $root }}"
+        # Fixed in daemonset even in deployment. Both pods are the same, but only daemonset as twistlock.
+        - name: DEFENDER_TYPE
+          value: "daemonset"
+        - name: DEFENDER_LISTENER_TYPE
+          value: "{{ .Values.config.defender.listenerType }}"
+        - name: DOCKER_CLIENT_ADDRESS
+          value: "{{ .Values.config.docker.clientAddress }}"
+        - name: DEFENDER_CLUSTER_ID
+          value: "{{ .Values.config.clusterId }}"
+        - name: MONITOR_SERVICE_ACCOUNTS
+          value: "{{ .Values.config.monitor.serviceAccounts }}"
+        - name: MONITOR_ISTIO
+          value: "{{ .Values.config.monitor.istio }}"
+        # https://docs.twistlock.com/docs/19.07/install/install_defender/install_rasp_defender.html#embed-rasp-defender-manually
+        - name: INSTALL_BUNDLE
+          value: "{{ .Values.config.installBundle }}"
+        {{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - "{{ template "twistlock-defender.fullname" . }}"
+            topologyKey: kubernetes.io/hostname
+      {{- with .Values.deployment.affinity }}
+{{ tpl (toYaml .) $root | indent 8 }}
+      {{- end }}
+      tolerations:
+      {{- with .Values.tolerations }}
+{{ tpl (toYaml .) $root | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: certificates
+        secret:
+          secretName: {{ template "twistlock-defender.fullname" . }}
+          defaultMode: 256
+      - name: syslog-socket
+        hostPath:
+          path: "/dev/log"
+      - name: host-root
+        hostPath:
+          path: "/"
+      - name: data-path
+        hostPath:
+          path: "{{ .Values.volumes.data }}"
+      - name: docker-sock-path
+        hostPath:
+          path: "{{ .Values.volumes.docker.sockPath }}"
+      - name: docker-netns
+        hostPath:
+          path: "{{ .Values.volumes.docker.netns }}"
+      - name: passwd
+        hostPath:
+          path: "/etc/passwd"
+      - name: auditd-log
+        hostPath:
+          path: "/var/log/audit"
+      {{- if and .Values.volumes.iptablesFlockPath .Values.volumeMounts.iptablesFlockPath }}
+      - name: iptables-lock
+        hostPath:
+          path: "{{ .Values.volumes.iptablesFlockPath }}"
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
+      {{- end }}
+      {{- if .Values.useHostPID }}
+      hostPID: true
+      {{- end }}
+      {{- if .Values.useHostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+{{- end }}

--- a/twistlock-defender/templates/secret.yaml
+++ b/twistlock-defender/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "twistlock-defender.fullname" . }}
+  labels:
+    app: {{ template "twistlock-defender.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+type: Opaque
+data:
+  service-parameter: {{ .Values.secret.service_parameter }}
+  ca.pem: {{ .Values.secret.ca_cert }}
+  client-cert.pem: {{ .Values.secret.client_cert }}
+  client-key.pem: {{ .Values.secret.client_key }}

--- a/twistlock-defender/templates/serviceaccount.yaml
+++ b/twistlock-defender/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "twistlock-defender.fullname" . }}
+  labels:
+    app: {{ template "twistlock-defender.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+secrets:
+- name: {{ template "twistlock-defender.fullname" . }}

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -37,7 +37,7 @@ config:
   defender:
     type: "daemonset"
     listenerType: "none"
-  clusterId: "%CLUSTERID%"
+  clusterId: "CLUSTERID"
   monitor:
     serviceAccounts: "true"
     istio: "false"
@@ -66,10 +66,10 @@ securityContext:
     - AUDIT_CONTROL
 
 secret:
-  ca_cert: "%CA_CERT%"
-  client_cert: "%CLIENT_CERT%"
-  client_key: "%CLIENT_KEY%"
-  service_parameter: "%SERVICE_PARAMETER%"
+  ca_cert: "CA_CERT"
+  client_cert: "CLIENT_CERT"
+  client_key: "CLIENT_KEY"
+  service_parameter: "SERVICE_PARAMETER"
 
 useHostNetwork: true
 useHostPID: true

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -1,0 +1,94 @@
+fullnameOverride: ""
+nameOverride: ""
+
+accessToken: "accessToken"
+
+console:
+  dnsName: twistlock-console
+  port: "8084"
+
+image:
+  repository: "registry-auth.twistlock.com/tw_{{ .Values.accessToken }}/twistlock/defender"
+  tag: "defender{{ .Values.config.docker.tag }}"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+volumeMounts:
+  data: "/var/lib/twistlock"
+  certificates: "/var/lib/twistlock/certificates"
+  docker:
+    sockPath: "/var/run"
+    netns: "/var/run/docker/netns"
+  iptablesFlockPath: "/run"
+
+volumes:
+  data: "/var/lib/twistlock/defender"
+  docker:
+    sockPath: "/var/run"
+    netns: "/var/run/docker/netns"
+  iptablesFlockPath: "/run"
+  passwd: "/etc/passwd"
+  auditLog: "/var/log/audit"
+  syslog: "/dev/log"
+
+config:
+  console:
+    wsAddress: wss://{{ .Values.console.dnsName }}:{{ .Values.console.port }}
+  defender:
+    type: "daemonset"
+    listenerType: "none"
+  clusterId: "%CLUSTERID%"
+  monitor:
+    serviceAccounts: "true"
+    istio: "false"
+  # https://docs.twistlock.com/docs/19.07/install/install_defender/install_rasp_defender.html#embed-rasp-defender-manually
+  installBundle: ""
+  docker:
+    clientAddress: "/var/run/docker.sock"
+    tag: "_19_07_363"
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+securityContext:
+  readOnlyRootFilesystem: true
+  privileged: true
+  capabilities:
+    add:
+    - NET_ADMIN
+    - SYS_ADMIN
+    - SYS_PTRACE
+    - AUDIT_CONTROL
+
+secret:
+  ca_cert: "%CA_CERT%"
+  client_cert: "%CLIENT_CERT%"
+  client_key: "%CLIENT_KEY%"
+  service_parameter: "%SERVICE_PARAMETER%"
+
+useHostNetwork: true
+useHostPID: true
+
+deployment:
+  enabled: false
+  annotations: {}
+  replicas: 1
+  strategy: {}
+  affinity: {}
+
+daemonset:
+  enabled: true
+  annotations: {}
+  updateStrategy:
+    type: RollingUpdate
+
+podAnnotations: {}
+tolerations: []
+extraEnv: []
+extraVolumeMounts: []
+extraVolumes: []


### PR DESCRIPTION
- twistlock console, defender chart
  - document: https://docs.twistlock.com/docs/
      - You need access token...
- You can install defender with daemonset or deployment
   - Default is daemonset.
- An access token is also required to pull image, the test cannot be performed and `Makefile` is dummy.