### PR TITLE
SRE-1226: Add prove to twistlock charts

### DIFF
--- a/twistlock-console/Chart.yaml
+++ b/twistlock-console/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: twistlock-console
-version: "0.0.1"
+version: "0.0.2"
 appVersion: "19.07.363"
 description: Chart for Twistlock Console
 home: https://www.twistlock.com/

--- a/twistlock-console/README.md
+++ b/twistlock-console/README.md
@@ -67,6 +67,8 @@ The following table lists the configurable parameters of the gaurd chart and the
 |  `deployment.strategy` | Deployment update strategy | `"{}"`|
 |  `podAnnotations` | Pod annotations | `{}`|
 |  `tolerations` | Pod tolerations | `[]`|
+|  `livenessProve` | Pod livenessProve | `tcpSocket.port: {{ .Values.port.management.https }}`|
+|  `readinessProve` | Pod readinessProve | `tcpSocket.port: {{ .Values.port.management.https }}`|
 |  `extraEnv` | Pod extra environment value | `[]`|
 |  `extraVolumeMounts` | Pod extra volumeMounts | `[]`|
 |  `extraVolume` | Pod extra volume | `[]`|

--- a/twistlock-console/templates/deployment.yaml
+++ b/twistlock-console/templates/deployment.yaml
@@ -56,6 +56,14 @@ spec:
         - name: ha
           containerPort: {{ .Values.port.highAvailability }}
         {{- end }}
+        {{- with .Values.livenssProbe }}
+        livenssProbe:
+{{ tpl (toYaml .) $root | indent 8 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+{{ tpl (toYaml .) $root | indent 8 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 8 }}
         env:

--- a/twistlock-console/templates/deployment.yaml
+++ b/twistlock-console/templates/deployment.yaml
@@ -58,14 +58,14 @@ spec:
         {{- end }}
         {{- with .Values.livenssProbe }}
         livenssProbe:
-{{ tpl (toYaml .) $root | indent 8 }}
+{{ tpl (toYaml .) $root | indent 10 }}
         {{- end }}
         {{- with .Values.readinessProbe }}
         readinessProbe:
-{{ tpl (toYaml .) $root | indent 8 }}
+{{ tpl (toYaml .) $root | indent 10 }}
         {{- end }}
         resources:
-{{ toYaml .Values.resources | indent 8 }}
+{{ toYaml .Values.resources | indent 10 }}
         env:
         - name: CONFIG_PATH
           value: /data/config/twistlock.cfg

--- a/twistlock-console/values.yaml
+++ b/twistlock-console/values.yaml
@@ -97,6 +97,14 @@ ingress:
 
 secrets: {}
 
+livenssProbe:
+  tcpSocket:
+    port: "{{ .Values.port.management.https }}"
+
+readinessProbe:
+  tcpSocket:
+    port: "{{ .Values.port.management.https }}"
+
 serviceAccount:
   annotations: {}
 

--- a/twistlock-defender/Chart.yaml
+++ b/twistlock-defender/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: twistlock-defender
-version: 0.0.1
+version: 0.0.2
 appVersion: "19.07.363"
 description: Chart for Twistlock Defender
 home: https://www.twistlock.com/

--- a/twistlock-defender/README.md
+++ b/twistlock-defender/README.md
@@ -95,3 +95,5 @@ The following table lists the configurable parameters of the gaurd chart and the
 |  `extraEnv` | Pod extra environment value | `[]`|
 |  `extraVolumeMounts` | Pod extra volumeMounts | `[]`|
 |  `extraVolume` | Pod extra volume | `[]`|
+|  `livenessProve` | Pod livenessProve | `{}`|
+|  `readinessProve` | Pod readinessProve | `{}`|

--- a/twistlock-defender/templates/daemonset.yaml
+++ b/twistlock-defender/templates/daemonset.yaml
@@ -69,6 +69,14 @@ spec:
         {{- with .Values.extraEnv }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+        {{- with .Values.livenssProbe }}
+        livenssProbe:
+{{ tpl (toYaml .) $root | indent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+{{ tpl (toYaml .) $root | indent 10 }}
+        {{- end }}
         volumeMounts:
         - name: host-root
           mountPath: "/host"

--- a/twistlock-defender/templates/deployment.yaml
+++ b/twistlock-defender/templates/deployment.yaml
@@ -73,6 +73,14 @@ spec:
         {{- with .Values.extraVolumeMounts }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+        {{- with .Values.livenssProbe }}
+        livenssProbe:
+{{ tpl (toYaml .) $root | indent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+{{ tpl (toYaml .) $root | indent 10 }}
+        {{- end }}
         env:
         - name: LOG_PROD
           value: "true"

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -92,3 +92,6 @@ tolerations: []
 extraEnv: []
 extraVolumeMounts: []
 extraVolumes: []
+
+livenssProbe: {}
+readinessProbe: {}


### PR DESCRIPTION
- Bump chart version
- Add prove for twistlock-console and defender
  - The defender seems to have no items to check, but it can be added later.