### PR TITLE
[ci] check the chart version was bumped

### DIFF
--- a/.circleci/check-version.sh
+++ b/.circleci/check-version.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -u
+
+FROM=remotes/origin/master
+PWD="$(pwd)"
+NAME="$(basename ${PWD})"
+
+# If there is no diff in the current directory, then exit 0
+DIFF="$(git --no-pager diff --name-only "${FROM}" HEAD .)"
+if [ -z "${DIFF}" ]; then
+  echo "[${NAME}] none diff"
+  exit 0
+fi
+
+# Check whether the version in Chart.yaml was updated or not.
+DIFF_CHART_YAML="$(git --no-pager diff "${FROM}" HEAD Chart.yaml | grep 'version: ')"
+
+echo "========================================"
+echo " [${NAME}] diff version"
+echo "${DIFF_CHART_YAML}"
+echo "========================================"
+
+if [ -z "${DIFF_CHART_YAML}" ]; then
+  echo "You must bump the Chart version!"
+  exit 1
+fi
+
+# If the updated version was lower than the base branch, it causes an error.
+VERSIONS=$(echo "${DIFF_CHART_YAML}"| sed -e 's/[+-]version: //g' -e "s/[\"\' ]//g")
+SORTED=$(echo "${VERSIONS}" | sort --version-sort | uniq)
+DIFF_VERSION="$(diff -u <(echo "${VERSIONS}") <(echo "${SORTED}"))"
+
+if [ -n "${DIFF_VERSION}" ]; then
+  echo "You must bump Chart version!"
+  exit 1
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - run: make ci:enable:k8s
       - run: make ci:enable:helm
       - run: make ci:diff
+      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && ../.circleci/check-version.sh || exit 255"
       - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make apply || exit 255"
       - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make test || exit 255" || (make ci:dump && exit 1)
   publish:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+#### Checklist
+
+- [ ] Chart Version bumped
+
+


### PR DESCRIPTION
This PR adds a checker into ci. The checker does confirm whether it updates the chart version was bumped and cause an error if the chart version didn't bump. As a result, we can prevent to merge the chart didn't bump version.

## Execution examples

- PASSED: bumped the version 
  https://github.com/chatwork/charts/compare/check-version-was-bumped...50f900c
  https://circleci.com/gh/chatwork/charts/903
  ```
  ========================================
  [php] diff version
  -version: 0.13.3
  +version: 0.13.4
  ========================================
  ```
  
- FAILED: did not change the version 
  https://github.com/chatwork/charts/compare/check-version-was-bumped...ab8f24a
  https://circleci.com/gh/chatwork/charts/904
  ```
  ========================================
  [php] diff version
  
  ========================================
  You must bump the Chart version!
  ```

- FAILED: changed the version to lower
  https://github.com/chatwork/charts/compare/check-version-was-bumped...90446a5
  https://circleci.com/gh/chatwork/charts/905
  ```
  ========================================
  [php] diff version
  -version: 0.13.3
  +version: 0.13.2
  ========================================
  You must bump Chart version!
  ```

- PASSED: added a new chart
  https://github.com/chatwork/charts/compare/check-version-was-bumped...5d92d6d
  https://circleci.com/gh/chatwork/charts/906
  ```
  ========================================
  [new-chart] diff version
  +version: 0.0.1
  ========================================
  ```

- PASSED: bumped the version and stripped quotes 
  https://github.com/chatwork/charts/compare/check-version-was-bumped...7665d88
  https://circleci.com/gh/chatwork/charts/907
  ```
  ========================================
  [twistlock-console] diff version
  -version: "0.0.3"
  +version: 0.0.4
  ========================================
  ```