### PR TITLE
[postfix] fixes use only hostNetwork in mailcatcher tests

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Postfix Helm Chart
 name: postfix
-version: 0.2.0
+version: 0.2.1

--- a/postfix/templates/test/test-pod-mailcatcher.yaml
+++ b/postfix/templates/test/test-pod-mailcatcher.yaml
@@ -27,7 +27,7 @@ spec:
         - -c
         - |
         {{- if .Values.daemonset.enabled }}
-          export SMTPHOST="${NODE_IP}:{{ .Values.daemonset.hostPort }}" \
+          export SMTPHOST="${NODE_IP}:{{ .Values.daemonset.hostPort | default 25 }}" \
         {{- end }}
         {{- if .Values.deployment.enabled }}
           export SMTPHOST="{{ template "postfix.fullname" . }}:{{ .Values.deployment.service.port }}" \


### PR DESCRIPTION
https://github.com/chatwork/charts/blob/master/postfix/templates/daemonset.yaml#L48-L53
If `hostNetwork` is enabled with `hostPort` omitted, access is made with `containerPort` 25.
However, the `hostPort` was required for testing.

#### Checklist

- [X] Chart Version bumped


