### PR TITLE
[php] fixes YAML was broken by service extraPorts

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.13.3
+version: 0.13.4
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/templates/service.yaml
+++ b/php/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
 {{- range .Values.nginx.extraPorts }}
   - name: {{ .name }}
     port: {{ .containerPort }}
-    {{- with .protocol }}protocol: {{ . }}{{ end }}
+    {{ with .protocol }}protocol: {{ . }}{{ end }}
     targetPort: {{ .name | default .containerPort }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The problem that YAML breaks

**values.yaml**
```
nginx:
  extraPorts:
  - name: health
    containerPort: 7777
    protocol: TCP
```

**result**
```yaml
spec:
  type: ClusterIP
  ports:
  - name: health
    port: 7777protocol: TCP
    targetPort: health
```

#### Checklist

- [X] Chart Version bumped


