### PR TITLE
[php] support securityContext

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.13.6
+version: 0.13.7
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `podAnnotation` | Annotation specified for pod in deployment | {} |
 |  `imagePullSecrets` | Name of Secret resource containing private registry credentials | `[]` |
 |  `restartPolicy` | Container restart policy | `""` |
+|  `serviceAccountName` | Enable security context | `""` |
 |  `serviceAccountName` | Existing ServiceAccount to use | `""` |
 |  `extraVolumes` | Additional volumes to all container | `[]` |
 |  `extraVolumeMounts` | Additional volumeMounts to all container | `[]` |

--- a/php/README.md
+++ b/php/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `podAnnotation` | Annotation specified for pod in deployment | {} |
 |  `imagePullSecrets` | Name of Secret resource containing private registry credentials | `[]` |
 |  `restartPolicy` | Container restart policy | `""` |
-|  `serviceAccountName` | Enable security context | `""` |
+|  `securityContext` | Enable security context | `""` |
 |  `serviceAccountName` | Existing ServiceAccount to use | `""` |
 |  `extraVolumes` | Additional volumes to all container | `[]` |
 |  `extraVolumeMounts` | Additional volumeMounts to all container | `[]` |

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -245,6 +245,9 @@ spec:
       imagePullSecrets:
 {{ tpl (toYaml .) $root | indent 6 }}
 {{- end }}
+{{- with .Values.securityContext }}
+      securityContext: {{ . }}
+{{- end }}
 {{- with .Values.serviceAccountName }}
       serviceAccountName: {{ . }}
 {{- end }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -17,6 +17,8 @@ imagePullSecrets: []
 
 restartPolicy: ""
 
+securityContext: {}
+
 serviceAccountName: ""
 
 extraVolumes: []


### PR DESCRIPTION
IRSA must be supported for php chart to work with EKS.

```
$ ls -la /var/run/secrets/eks.amazonaws.com/serviceaccount/..2019_12_10_15_33_09.833408446/token
-rw------- 1 root root 1034 Dec 10 15:33 /var/run/secrets/eks.amazonaws.com/serviceaccount/..2019_12_10_15_33_09.833408446/token
```

Only root users can read and write tokens mounted with IRSA.
However, in PHP-FPM, it should be executed as the nobody user, and the token cannot be referenced from the nobody user.

https://docs.aws.amazon.com/en_pv/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html

So we will modify the `SecurityContext` based on this document.

#### Checklist

- [X] Chart Version bumped


