### PR TITLE
[postfix] change to be able to put other files in postfix directory

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Postfix Helm Chart
 name: postfix
-version: 0.2.1
+version: 0.3.0

--- a/postfix/templates/configmap.yaml
+++ b/postfix/templates/configmap.yaml
@@ -1,4 +1,4 @@
----
+{{- $root := . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,5 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  main_cf: |
-{{ tpl .Values.postfix.templates.main_cf . | indent 4 }}
+{{- range $k, $v := .Values.postfix.templates }}
+  {{ $k }}: |
+{{ tpl $v $root | indent 4 }}
+{{- end }}

--- a/postfix/templates/daemonset.yaml
+++ b/postfix/templates/daemonset.yaml
@@ -21,8 +21,8 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
       annotations:
-        checksum/main_cf: {{ tpl .Values.postfix.templates.main_cf . | sha256sum }}
-        checksum/sasl_passwd: {{ .Values.postfix.secrets.sasl_passwd | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/sasl_passwd: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- with .Values.daemonset.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -56,9 +56,11 @@ spec:
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         volumeMounts:
+{{- range $k, $v := .Values.postfix.templates }}
         - name: configmap
-          subPath: main_cf
-          mountPath: /etc/postfix/main.cf
+          subPath: {{ $k }}
+          mountPath: /etc/postfix/{{ $k }}
+{{- end }}
         - name: secret
           subPath: sasl_passwd
           mountPath: /etc/postfix/sasl_passwd

--- a/postfix/templates/deployment.yaml
+++ b/postfix/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
       annotations:
-        checksum/main_cf: {{ tpl .Values.postfix.templates.main_cf . | sha256sum }}
-        checksum/sasl_passwd: {{ .Values.postfix.secrets.sasl_passwd | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/sasl_passwd: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- with .Values.deployment.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -54,9 +54,12 @@ spec:
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 12 }}
         volumeMounts:
+
+{{- range $k, $v := .Values.postfix.templates }}
         - name: configmap
-          subPath: main_cf
-          mountPath: /etc/postfix/main.cf
+          subPath: {{ $k }}
+          mountPath: /etc/postfix/{{ $k }}
+{{- end }}
         - name: secret
           subPath: sasl_passwd
           mountPath: /etc/postfix/sasl_passwd

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -81,7 +81,11 @@ deployment:
 
 postfix:
   templates:
-    main_cf: |
+    auth_info: |
+      aaa
+      bbb
+      ccc
+    main.cf: |
       # Global Postfix configuration file. This file lists only a subset
       # of all parameters. For the syntax, and for a complete parameter
       # list, see the postconf(5) manual page (command: "man 5 postconf").


### PR DESCRIPTION
I have a use case that uses `sender_dependent_relayhost_maps`.
For that reason, it was changed so that files could be placed in the postfix directory.

#### Checklist

- [X] Chart Version bumped


