### PR TITLE
[postfix] support tpl for secrets

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Postfix Helm Chart
 name: postfix
-version: 0.3.0
+version: 0.4.0

--- a/postfix/templates/secret.yaml
+++ b/postfix/templates/secret.yaml
@@ -10,4 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  sasl_passwd: {{ .Values.postfix.secrets.sasl_passwd | b64enc | quote }}
+  sasl_passwd: {{ tpl .Values.postfix.secrets.sasl_passwd . | b64enc | quote }}

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -81,10 +81,6 @@ deployment:
 
 postfix:
   templates:
-    auth_info: |
-      aaa
-      bbb
-      ccc
     main.cf: |
       # Global Postfix configuration file. This file lists only a subset
       # of all parameters. For the syntax, and for a complete parameter


### PR DESCRIPTION
Supported `tpl` with `sasl_passwd` to use helmfile  vals.

**values.yaml**
```
postfix:
  secrets:
    sasl_passwd: |
      [smtp.sendgrid.net]:587 {{ .Values.username }}:{{ .Values.password }}

username: sendgrid-user
passowrd:  ref+awsssm://path/to/password?region=ap-northeast-1
```

#### Checklist

- [X] Chart Version bumped


