### PR TITLE
[postfix] remove default sasl_passwd

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Postfix Helm Chart
 name: postfix
-version: 0.5.0
+version: 0.5.1

--- a/postfix/templates/daemonset.yaml
+++ b/postfix/templates/daemonset.yaml
@@ -22,7 +22,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.postfix.secrets.sasl_passwd }}
         checksum/sasl_passwd: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.daemonset.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -61,10 +63,12 @@ spec:
           subPath: {{ $k }}
           mountPath: /etc/postfix/{{ $k }}
 {{- end }}
+        {{- if .Values.postfix.secrets.sasl_passwd }}
         - name: secret
           subPath: sasl_passwd
           mountPath: /etc/postfix/sasl_passwd
           readOnly: true
+        {{- end }}
         - name: spool
           mountPath: /var/spool/postfix
           {{- if .Values.persistence.subPath }}
@@ -77,9 +81,11 @@ spec:
       - name: configmap
         configMap:
           name: {{ template "postfix.fullname" . }}-configmap
+      {{- if .Values.postfix.secrets.sasl_passwd }}
       - name: secret
         secret:
           secretName: {{ template "postfix.fullname" . }}-secret
+      {{- end }}
       - name: spool
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/postfix/templates/deployment.yaml
+++ b/postfix/templates/deployment.yaml
@@ -27,7 +27,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.postfix.secrets.sasl_passwd }}
         checksum/sasl_passwd: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.deployment.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -60,10 +62,12 @@ spec:
           subPath: {{ $k }}
           mountPath: /etc/postfix/{{ $k }}
 {{- end }}
+        {{- if .Values.postfix.secrets.sasl_passwd }}
         - name: secret
           subPath: sasl_passwd
           mountPath: /etc/postfix/sasl_passwd
           readOnly: true
+        {{- end }}
         - name: spool
           mountPath: /var/spool/postfix
           {{- if .Values.persistence.subPath }}
@@ -76,9 +80,11 @@ spec:
       - name: configmap
         configMap:
           name: {{ template "postfix.fullname" . }}-configmap
+      {{- if .Values.postfix.secrets.sasl_passwd }}
       - name: secret
         secret:
           secretName: {{ template "postfix.fullname" . }}-secret
+      {{- end }}
       - name: spool
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/postfix/templates/secret.yaml
+++ b/postfix/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postfix.secrets.sasl_passwd }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,3 +12,4 @@ metadata:
 type: Opaque
 data:
   sasl_passwd: {{ tpl .Values.postfix.secrets.sasl_passwd . | b64enc | quote }}
+{{- end }}

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -773,21 +773,12 @@ postfix:
       # Postfix の名前解決では、サービス名が引けないので native を指定
       smtp_host_lookup = native
       relayhost = [{{ include "postfix.fullname" . }}-mailcatcher]:1025
-      {{- else }}
-      # @see https://sendgrid.kke.co.jp/docs/Integrate/Mail_Servers/postfix.html
-      smtp_sasl_auth_enable = yes
-      smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
-      smtp_sasl_security_options = noanonymous
-      smtp_sasl_tls_security_options = noanonymous
-      smtp_tls_security_level = encrypt
-      header_size_limit = 4096000
-      relayhost = [smtp.sendgrid.net]:587
       {{- end }}
-  secrets:
+  secrets: {}
     # dummy value
     # @see https://sendgrid.kke.co.jp/docs/Integrate/Mail_Servers/postfix.html
-    sasl_passwd: |-
-      [smtp.sendgrid.net]:587 yourSendGridUsername:yourSendGridPassword
+    # sasl_passwd: |-
+    #   [smtp.sendgrid.net]:587 yourSendGridUsername:yourSendGridPassword
 
 # for helm test
 test:


### PR DESCRIPTION
`sasl_passwd` is not required for use cases such as relaying with postfix.

#### Checklist

- [X] Chart Version bumped


