### PR TITLE
[php] removed replicaCount from default values

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.13.10
+version: 0.13.11
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -6,7 +6,7 @@
 sharedPath: /var/www/html
 
 # DEPLOYMENT
-replicaCount: 1
+#replicaCount: 1
 
 strategy:
   type: RollingUpdate


### PR DESCRIPTION
Removed `replicaCount` from default values
Because the scaled replicas of the deployment are forced to default values.

#### Checklist

- [X] Chart Version bumped
