### PR TITLE
[php] fixes graceful shutdown

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.13.11
+version: 0.13.12
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -69,7 +69,7 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `extras.templates` | Additional raw Kubernetes resources | `{}` |
 |  `test.enabled` | Enables helm test | `true` |
 
-### Init Containers
+### Init containers
 
 Initialize using busybox.
 By default, we use [busybox](https://hub.docker.com/_/busybox), but you can use your container.
@@ -91,7 +91,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `busybox.templates` | Additional ConfigMap as a string to be passed to the tpl function. | `{}` |
 |  `busybox.annotations` | Grant annotations to ConfigMap of `busybox.templates`, Secrets of `busybox.secrets` | `{}` |
 
-## Nginx Containers
+## Nginx containers
 
 |  Parameter | Description | Default |
 | --- | --- | --- |
@@ -125,7 +125,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `nginx.templates` | Additional ConfigMap as a string to be passed to the tpl function. | setting `nginx.conf`, `conf.d/default.conf`, `conf.d/status.conf` |
 |  `nginx.annotations` | Grant annotations to ConfigMap of `nginx.templates`, Secrets of `nginx.secrets` | `{}` |
 
-## PHP Containers
+## PHP containers
 
 |  Parameter | Description | Default |
 | --- | --- | --- |

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -125,9 +125,6 @@ spec:
               command:
 {{ tpl (toYaml .) $root | indent 14 }}
 {{- end }}
-{{- with .Values.nginx.terminationGracePeriodSeconds }}
-        terminationGracePeriodSeconds: {{ . }}
-{{- end }}
         volumeMounts:
 {{- if .Values.busybox.enabled }}
         - name: share
@@ -191,9 +188,6 @@ spec:
             exec:
               command:
 {{ tpl (toYaml .) $root | indent 14 }}
-{{- end }}
-{{- with .Values.fpm.terminationGracePeriodSeconds }}
-        terminationGracePeriodSeconds: {{ . }}
 {{- end }}
         volumeMounts:
 {{- if .Values.busybox.enabled }}
@@ -264,8 +258,8 @@ spec:
 {{- with .Values.serviceAccountName }}
       serviceAccountName: {{ . }}
 {{- end }}
-{{- with .Values.fpm.processControlTimeout }}
-      terminationGracePeriodSeconds: {{ add . 10 }}
+{{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
 {{- end }}
 {{- with .Values.affinity }}
       affinity:

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -246,7 +246,7 @@ nginx:
     conf.d:
       default.conf: |
         server {
-            listen      80;
+            listen      {{ .Values.nginx.port }};
             server_name localhost;
             root        /var/www/html;
             index       index.php index.html index.htm;

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -25,6 +25,8 @@ extraVolumes: []
 
 extraVolumeMounts: []
 
+terminationGracePeriodSeconds: 70
+
 tolerations: []
 
 affinity: {}
@@ -137,9 +139,7 @@ nginx:
   lifecycle:
     postStart: []
     # postStart: ["/bin/sh", "-c", "echo Hello > /tmp/message"]
-    preStop: []
-
-  terminationGracePeriodSeconds:
+    preStop: ["/bin/sh", "-c", "sleep 5; nginx -s quit; sleep 60"]
 
   livenessProbe:
     httpGet:
@@ -302,13 +302,7 @@ fpm:
   lifecycle:
     postStart: []
     # postStart: ["/bin/sh", "-c", "echo Hello > /tmp/message"]
-    preStop: []
-
-  terminationGracePeriodSeconds:
-
-  pm:
-    maxChildren: 5
-    maxRequests: 500
+    preStop: ["/bin/sh", "-c", "sleep 5; kill -QUIT 1; sleep 60"]
 
   livenessProbe: {}
   readinessProbe: {}
@@ -523,7 +517,7 @@ fpm:
       ; Available units: s(econds), m(inutes), h(ours), or d(ays)
       ; Default Unit: seconds
       ; Default Value: 0
-      process_control_timeout = 0
+      process_control_timeout = 60
 
       ; The maximum number of processes FPM will fork. This has been designed to control
       ; the global number of processes when using dynamic PM within a lot of pools.
@@ -826,11 +820,7 @@ fpm:
         ;       anything, but it may not be a good idea to use the .php extension or it
         ;       may conflict with a real PHP file.
         ; Default Value: not set
-        {{- with .Values.fpm.pm.status }}
-        pm.status_path = {{ . }}
-        {{- else }}
-        ;pm.status_path = /status
-        {{- end }}
+        ;pm.status_path = /statu
 
         ; The ping URI to call the monitoring page of FPM. If this value is not set, no
         ; URI will be recognized as a ping page. This could be used to test from outside
@@ -1012,8 +1002,6 @@ fpm:
         ;php_admin_value[error_log] = /var/log/fpm-php.www.log
         ;php_admin_flag[log_errors] = on
         ;php_admin_value[memory_limit] = 32M
-        php_admin_value[error_log] = /dev/stderr
-        php_admin_flag[log_errors] = on
 
   # Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets`.
   annotations: {}


### PR DESCRIPTION
The description of graceful shutdown was incorrect and fixed.
Nginx waits for php-fpm to end on in-flight requests, so you don't have to wait on `PreStop`.

#### Checklist

- [X] Chart Version bumped

