### PR TITLE
[php] update nginx and php-fpm version

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.15.2
+version: 0.16.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -100,7 +100,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  Parameter | Description | Default |
 | --- | --- | --- |
 |  `nginx.image.repository` | The image repository to pull from | `nginx` |
-|  `nginx.image.tag` | The image tag to pull | `1.15.1-alpine` |
+|  `nginx.image.tag` | The image tag to pull | `1.17-alpine` |
 |  `nginx.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 |  `nginx.command` | Command to execute | `[]` |
 |  `nginx.containerPort` | Listen port of NGINX container | `80` |
@@ -122,7 +122,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  Parameter | Description | Default |
 | --- | --- | --- |
 |  `fpm.image.repository` | The image repository to pull from | `php` |
-|  `fpm.image.tag` | The image tag to pull | `7.1-fpm-alpine` |
+|  `fpm.image.tag` | The image tag to pull | `7.4-fpm-alpine` |
 |  `fpm.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 |  `fpm.command` | Command to execute | `[]` |
 |  `fpm.lifecycle` | PHP-FPM container lifecycle hooks | `{}` |
@@ -173,3 +173,81 @@ fpm:
   lifecycle:
     preStop: ["/bin/sh", "-c", "sleep 5; kill -QUIT 1; sleep {{ $fpm_request_timeout }} "]
 ```
+
+### Manage PHP-FPM logging
+
+To output PHP errors as container logs, configure as follows.
+
+**php.ini**
+
+```
+; Besides displaying errors, PHP can also log errors to locations such as a
+; server-specific log, STDERR, or a location specified by the error_log
+; directive found below. While errors should not be displayed on productions
+; servers they should still be monitored and logging is a great way to do that.
+; Default Value: Off
+; Development Value: On
+; Production Value: On
+; http://php.net/log-errors
+log_errors = On
+
+; Set maximum length of log_errors. In error_log information about the source is
+; added. The default is 1024 and 0 allows to not apply any maximum length at all.
+; http://php.net/log-errors-max-len
+log_errors_max_len = 4096
+```
+
+**php-fpm.conf**
+
+```
+[global]
+; Error log file
+; If it's set to "syslog", log is sent to syslogd instead of being written
+; into a local file.
+; Note: the default prefix is /usr/local/var
+; Default Value: log/php-fpm.log
+error_log = /proc/self/fd/2
+
+; Log limit on number of characters in the single line (log entry). If the
+; line is over the limit, it is wrapped on multiple lines. The limit is for
+; all logged characters including message prefix and suffix if present. However
+; the new line character does not count into it as it is present only when
+; logging to a file descriptor. It means the new line character is not present
+; when logging to syslog.
+; Default Value: 1024
+log_limit = 4096
+```
+
+**php-fpm.d/www.conf**
+
+```
+[www]
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+catch_workers_output = yes
+
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+decorate_workers_output = no
+```
+
+Set `log_errors_max_len` and `log_limit` according to the log length.
+By setting `decorate_workers_output`, you can remove PHP-FPM specific output prefix.
+
+```
+$ kc logs -c php-fpm php-669bc99b68-t958q --timestamps -f 
+2020-02-12T06:26:27.057182729Z [12-Feb-2020 06:26:27] NOTICE: fpm is running, pid 1
+2020-02-12T06:26:27.058596594Z [12-Feb-2020 06:26:27] NOTICE: ready to handle connections
+2020-02-12T06:29:41.989949895Z NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function hoge() in /var/www/html/index.php:1
+2020-02-12T06:29:41.989996608Z Stack trace:
+2020-02-12T06:29:41.990004596Z #0 {main}
+2020-02-12T06:29:41.990008076Z   thrown in /var/www/html/index.php on line 1
+```
+
+Since the log cannot be combined into one line in the PHP setting, use [set_error_handler](https://www.php.net/manual/ja/function.set-error-handler.php) or [set_execption_handler](https://www.php.net/manual/ja/function.set-exception-handler.php) to solve the problem with the application.

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -68,7 +68,7 @@ busybox:
   # `busybox.command` is initialize command.
   # Copy the source code in busybox to `sharedPath` or `busybox.sharedPath`.
   # e.g. sh -c "cp -av /path/to/sources/* /path/to/share-path"
-  command: ["sh", "-c", "echo '<?php phpinfo();' > /var/www/html/index.php"]
+  command: ["sh", "-c", "echo '<?php hoge();' > /var/www/html/index.php"]
 
   # `busybox.sharedPath` is specifies the directory to mount.
   # Default is `sharedPath`, but if it conflicts with the source code directory, please specify it.
@@ -141,7 +141,7 @@ busybox:
 nginx:
   image:
     repository: nginx
-    tag: 1.15.1-alpine
+    tag: 1.17-alpine
     pullPolicy: IfNotPresent
 
   # custom command for nginx image execution
@@ -308,7 +308,7 @@ nginx:
 fpm:
   image:
     repository: php
-    tag: 7.1-fpm-alpine
+    tag: 7.4-fpm-alpine
     pullPolicy: IfNotPresent
 
   # custom command for php-fpm image execution
@@ -403,7 +403,7 @@ fpm:
       ; 5. The web server's directory (for SAPI modules), or directory of PHP
       ; (otherwise in Windows)
       ; 6. The directory from the --with-config-file-path compile time option, or the
-      ; Windows directory (C:\windows or C:\winnt)
+      ; Windows directory (usually C:\windows)
       ; See the PHP docs for more specific information.
       ; http://php.net/configuration.file
 
@@ -446,9 +446,9 @@ fpm:
       ; An empty string can be denoted by simply not writing anything after the equal
       ; sign, or by using the None keyword:
 
-      ;  foo =         ; sets foo to an empty string
-      ;  foo = None    ; sets foo to an empty string
-      ;  foo = "None"  ; sets foo to the string 'None'
+      ; foo =         ; sets foo to an empty string
+      ; foo = None    ; sets foo to an empty string
+      ; foo = "None"  ; sets foo to the string 'None'
 
       ; If you use constants in your value, and these constants belong to a
       ; dynamically loaded extension (either a PHP extension or a Zend extension),
@@ -471,7 +471,7 @@ fpm:
       ; development version only in development environments, as errors shown to
       ; application users can inadvertently leak otherwise secure information.
 
-      ; This is php.ini-production INI file.
+      ; This is the php.ini-production INI file.
 
       ;;;;;;;;;;;;;;;;;;;
       ; Quick Reference ;
@@ -495,11 +495,6 @@ fpm:
       ;   Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
       ;   Development Value: E_ALL
       ;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
-
-      ; html_errors
-      ;   Default Value: On
-      ;   Development Value: On
-      ;   Production value: On
 
       ; log_errors
       ;   Default Value: Off
@@ -541,11 +536,6 @@ fpm:
       ;   Development Value: Off
       ;   Production Value: Off
 
-      ; track_errors
-      ;   Default Value: Off
-      ;   Development Value: On
-      ;   Production Value: Off
-
       ; variables_order
       ;   Default Value: "EGPCS"
       ;   Development Value: "GPCS"
@@ -557,7 +547,7 @@ fpm:
       ; Name for user-defined php.ini (.htaccess) files. Default is ".user.ini"
       ;user_ini.filename = ".user.ini"
 
-      ; To disable this feature set this option to empty value
+      ; To disable this feature set this option to an empty value
       ;user_ini.filename =
 
       ; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
@@ -636,7 +626,7 @@ fpm:
       ; Production Value: "form="
       ;url_rewriter.tags
 
-      ; URL rewriter will not rewrites absolute URL nor form by default. To enable
+      ; URL rewriter will not rewrite absolute URL nor form by default. To enable
       ; absolute URL rewrite, allowed hosts must be defined at RUNTIME.
       ; Refer to session.trans_sid_hosts for more details.
       ; Default Value: ""
@@ -682,7 +672,14 @@ fpm:
       ; callback-function.
       unserialize_callback_func =
 
-      ; When floats & doubles are serialized store serialize_precision significant
+      ; The unserialize_max_depth specifies the default depth limit for unserialized
+      ; structures. Setting the depth limit too high may result in stack overflows
+      ; during unserialization. The unserialize_max_depth ini setting can be
+      ; overridden by the max_depth option on individual unserialize() calls.
+      ; A value of 0 disables the depth limit.
+      ;unserialize_max_depth = 4096
+
+      ; When floats & doubles are serialized, store serialize_precision significant
       ; digits after the floating point. The default value ensures that when floats
       ; are decoded with unserialize, the data will remain the same.
       ; The value is also used for json_encode when encoding double values.
@@ -693,6 +690,7 @@ fpm:
       ; open_basedir, if set, limits all file operations to the defined directory
       ; and below.  This directive makes most sense if used in a per-directory
       ; or per-virtualhost web server configuration file.
+      ; Note: disables the realpath cache
       ; http://php.net/open-basedir
       ;open_basedir =
 
@@ -725,6 +723,7 @@ fpm:
       ; Determines the size of the realpath cache to be used by PHP. This value should
       ; be increased on systems where PHP opens many files to reflect the quantity of
       ; the file operations performed.
+      ; Note: if open_basedir is set, the cache is disabled
       ; http://php.net/realpath-cache-size
       ;realpath_cache_size = 4096k
 
@@ -749,6 +748,12 @@ fpm:
       ; Only affects if zend.multibyte is set.
       ; Default: ""
       ;zend.script_encoding =
+
+      ; Allows to include or exclude arguments from stack traces generated for exceptions
+      ; Default: Off
+      ; In production, it is recommended to turn this setting on to prohibit the output
+      ; of sensitive information in stack traces
+      zend.exception_ignore_args = On
 
       ;;;;;;;;;;;;;;;;;
       ; Miscellaneous ;
@@ -785,7 +790,7 @@ fpm:
       ;max_input_nesting_level = 64
 
       ; How many GET/POST/COOKIE input variables may be accepted
-      ; max_input_vars = 1000
+      ;max_input_vars = 1000
 
       ; Maximum amount of memory a script may consume (128MB)
       ; http://php.net/memory-limit
@@ -888,7 +893,7 @@ fpm:
       ; Set maximum length of log_errors. In error_log information about the source is
       ; added. The default is 1024 and 0 allows to not apply any maximum length at all.
       ; http://php.net/log-errors-max-len
-      log_errors_max_len = 1024
+      log_errors_max_len = 4096
 
       ; Do not log repeated messages. Repeated errors must occur in same file on same
       ; line unless ignore_repeated_source is set true.
@@ -902,7 +907,7 @@ fpm:
       ignore_repeated_source = Off
 
       ; If this parameter is set to Off, then memory leaks will not be shown (on
-      ; stdout or in the log). This has only effect in a debug compile, and if
+      ; stdout or in the log). This is only effective in a debug compile, and if
       ; error reporting includes E_WARNING in the allowed list
       ; http://php.net/report-memleaks
       report_memleaks = On
@@ -913,11 +918,12 @@ fpm:
       ; Store the last error/warning message in $php_errormsg (boolean). Setting this value
       ; to On can assist in debugging and is appropriate for development servers. It should
       ; however be disabled on production servers.
+      ; This directive is DEPRECATED.
       ; Default Value: Off
-      ; Development Value: On
+      ; Development Value: Off
       ; Production Value: Off
       ; http://php.net/track-errors
-      track_errors = Off
+      ;track_errors = Off
 
       ; Turn off normal error reporting and emit XML-RPC error XML
       ; http://php.net/xmlrpc-errors
@@ -930,11 +936,8 @@ fpm:
       ; error message as HTML for easier reading. This directive controls whether
       ; the error message is formatted as HTML or not.
       ; Note: This directive is hardcoded to Off for the CLI SAPI
-      ; Default Value: On
-      ; Development Value: On
-      ; Production value: On
       ; http://php.net/html-errors
-      html_errors = On
+      html_errors = Off
 
       ; If html_errors is set to On *and* docref_root is not empty, then PHP
       ; produces clickable error messages that direct to a page describing the error
@@ -971,6 +974,26 @@ fpm:
       ;error_log = php_errors.log
       ; Log errors to syslog (Event Log on Windows).
       ;error_log = syslog
+
+      ; The syslog ident is a string which is prepended to every message logged
+      ; to syslog. Only used when error_log is set to syslog.
+      ;syslog.ident = php
+
+      ; The syslog facility is used to specify what type of program is logging
+      ; the message. Only used when error_log is set to syslog.
+      ;syslog.facility = user
+
+      ; Set this to disable filtering control characters (the default).
+      ; Some loggers only accept NVT-ASCII, others accept anything that's not
+      ; control characters. If your logger accepts everything, then no filtering
+      ; is needed at all.
+      ; Allowed values are:
+      ;   ascii (all printable ASCII characters and NL)
+      ;   no-ctrl (all characters except control characters)
+      ;   all (all characters)
+      ;   raw (like "all", but messages are not split at newlines)
+      ; http://php.net/syslog.filter
+      ;syslog.filter = ascii
 
       ;windows.show_crt_warning
       ; Default value: 0
@@ -1039,7 +1062,7 @@ fpm:
       ; first used (Just In Time) instead of when the script starts. If these
       ; variables are not used within a script, having this directive on will result
       ; in a performance gain. The PHP directive register_argc_argv must be disabled
-      ; for this directive to have any affect.
+      ; for this directive to have any effect.
       ; http://php.net/auto-globals-jit
       auto_globals_jit = On
 
@@ -1121,9 +1144,9 @@ fpm:
 
       ; Directory in which the loadable extensions (modules) reside.
       ; http://php.net/extension-dir
-      ; extension_dir = "./"
+      ;extension_dir = "./"
       ; On windows:
-      ; extension_dir = "ext"
+      ;extension_dir = "ext"
 
       ; Directory where the temporary files should be placed.
       ; Defaults to the system default (see sys_get_temp_dir)
@@ -1164,10 +1187,9 @@ fpm:
 
       ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
       ; of the web tree and people will not be able to circumvent .htaccess security.
-      ; http://php.net/cgi.dicard-path
       ;cgi.discard_path=1
 
-      ; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
+      ; FastCGI under IIS supports the ability to impersonate
       ; security tokens of the calling client.  This allows IIS to define the
       ; security context that the request runs under.  mod_fastcgi under Apache
       ; does not currently support this feature (03/17/2002)
@@ -1254,64 +1276,64 @@ fpm:
       ; If you wish to have an extension loaded automatically, use the following
       ; syntax:
       ;
-      ;   extension=modulename.extension
+      ;   extension=modulename
       ;
-      ; For example, on Windows:
+      ; For example:
       ;
-      ;   extension=msql.dll
+      ;   extension=mysqli
       ;
-      ; ... or under UNIX:
+      ; When the extension library to load is not located in the default extension
+      ; directory, You may specify an absolute path to the library file:
       ;
-      ;   extension=msql.so
+      ;   extension=/path/to/extension/mysqli.so
       ;
-      ; ... or with a path:
+      ; Note : The syntax used in previous PHP versions ('extension=<ext>.so' and
+      ; 'extension='php_<ext>.dll') is supported for legacy reasons and may be
+      ; deprecated in a future PHP major version. So, when it is possible, please
+      ; move to the new ('extension=<ext>) syntax.
       ;
-      ;   extension=/path/to/extension/msql.so
+      ; Notes for Windows environments :
       ;
-      ; If you only provide the name of the extension, PHP will look for it in its
-      ; default extension directory.
+      ; - Many DLL files are located in the extensions/ (PHP 4) or ext/ (PHP 5+)
+      ;   extension folders as well as the separate PECL DLL download (PHP 5+).
+      ;   Be sure to appropriately set the extension_dir directive.
       ;
-      ; Windows Extensions
-      ; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5+)
-      ; extension folders as well as the separate PECL DLL download (PHP 5+).
-      ; Be sure to appropriately set the extension_dir directive.
-      ;
-      ;extension=php_bz2.dll
-      ;extension=php_curl.dll
-      ;extension=php_fileinfo.dll
-      ;extension=php_ftp.dll
-      ;extension=php_gd2.dll
-      ;extension=php_gettext.dll
-      ;extension=php_gmp.dll
-      ;extension=php_intl.dll
-      ;extension=php_imap.dll
-      ;extension=php_interbase.dll
-      ;extension=php_ldap.dll
-      ;extension=php_mbstring.dll
-      ;extension=php_exif.dll      ; Must be after mbstring as it depends on it
-      ;extension=php_mysqli.dll
-      ;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
-      ;extension=php_odbc.dll
-      ;extension=php_openssl.dll
-      ;extension=php_pdo_firebird.dll
-      ;extension=php_pdo_mysql.dll
-      ;extension=php_pdo_oci.dll
-      ;extension=php_pdo_odbc.dll
-      ;extension=php_pdo_pgsql.dll
-      ;extension=php_pdo_sqlite.dll
-      ;extension=php_pgsql.dll
-      ;extension=php_shmop.dll
+      ;extension=bz2
+      ;extension=curl
+      ;extension=ffi
+      ;extension=fileinfo
+      ;extension=gd2
+      ;extension=gettext
+      ;extension=gmp
+      ;extension=intl
+      ;extension=imap
+      ;extension=ldap
+      ;extension=mbstring
+      ;extension=exif      ; Must be after mbstring as it depends on it
+      ;extension=mysqli
+      ;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
+      ;extension=odbc
+      ;extension=openssl
+      ;extension=pdo_firebird
+      ;extension=pdo_mysql
+      ;extension=pdo_oci
+      ;extension=pdo_odbc
+      ;extension=pdo_pgsql
+      ;extension=pdo_sqlite
+      ;extension=pgsql
+      ;extension=shmop
 
       ; The MIBS data available in the PHP distribution must be installed.
       ; See http://www.php.net/manual/en/snmp.installation.php
-      ;extension=php_snmp.dll
+      ;extension=snmp
 
-      ;extension=php_soap.dll
-      ;extension=php_sockets.dll
-      ;extension=php_sqlite3.dll
-      ;extension=php_tidy.dll
-      ;extension=php_xmlrpc.dll
-      ;extension=php_xsl.dll
+      ;extension=soap
+      ;extension=sockets
+      ;extension=sodium
+      ;extension=sqlite3
+      ;extension=tidy
+      ;extension=xmlrpc
+      ;extension=xsl
 
       ;;;;;;;;;;;;;;;;;;;
       ; Module Settings ;
@@ -1348,7 +1370,7 @@ fpm:
       [iconv]
       ; Use of this INI entry is deprecated, use global input_encoding instead.
       ; If empty, default_charset or input_encoding or iconv.input_encoding is used.
-      ; The precedence is: default_charset < intput_encoding < iconv.input_encoding
+      ; The precedence is: default_charset < input_encoding < iconv.input_encoding
       ;iconv.input_encoding =
 
       ; Use of this INI entry is deprecated, use global internal_encoding instead.
@@ -1390,22 +1412,22 @@ fpm:
       ; the sqlite_dbpage virtual table.
       ; https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
       ; (for older SQLite versions, this flag has no use)
-      sqlite3.defensive = 1
+      ;sqlite3.defensive = 1
 
       [Pcre]
-      ;PCRE library backtracking limit.
+      ; PCRE library backtracking limit.
       ; http://php.net/pcre.backtrack-limit
       ;pcre.backtrack_limit=100000
 
-      ;PCRE library recursion limit.
-      ;Please note that if you set this value to a high number you may consume all
-      ;the available process stack and eventually crash PHP (due to reaching the
-      ;stack size limit imposed by the Operating System).
+      ; PCRE library recursion limit.
+      ; Please note that if you set this value to a high number you may consume all
+      ; the available process stack and eventually crash PHP (due to reaching the
+      ; stack size limit imposed by the Operating System).
       ; http://php.net/pcre.recursion-limit
       ;pcre.recursion_limit=100000
 
-      ;Enables or disables JIT compilation of patterns. This requires the PCRE
-      ;library to be compiled with JIT support.
+      ; Enables or disables JIT compilation of patterns. This requires the PCRE
+      ; library to be compiled with JIT support.
       ;pcre.jit=1
 
       [Pdo]
@@ -1416,13 +1438,8 @@ fpm:
       ;pdo_odbc.db2_instance_name
 
       [Pdo_mysql]
-      ; If mysqlnd is used: Number of cache slots for the internal result set cache
-      ; http://php.net/pdo_mysql.cache_size
-      pdo_mysql.cache_size = 2000
-
       ; Default socket name for local MySQL connects.  If empty, uses the built-in
       ; MySQL defaults.
-      ; http://php.net/pdo_mysql.default-socket
       pdo_mysql.default_socket=
 
       [Phar]
@@ -1462,10 +1479,6 @@ fpm:
       ;mail.log =
       ; Log mail to syslog (Event Log on Windows).
       ;mail.log = syslog
-
-      [SQL]
-      ; http://php.net/sql.safe-mode
-      sql.safe_mode = Off
 
       [ODBC]
       ; http://php.net/odbc.default-db
@@ -1508,39 +1521,6 @@ fpm:
       ; http://php.net/odbc.defaultbinmode
       odbc.defaultbinmode = 1
 
-      ;birdstep.max_links = -1
-
-      [Interbase]
-      ; Allow or prevent persistent links.
-      ibase.allow_persistent = 1
-
-      ; Maximum number of persistent links.  -1 means no limit.
-      ibase.max_persistent = -1
-
-      ; Maximum number of links (persistent + non-persistent).  -1 means no limit.
-      ibase.max_links = -1
-
-      ; Default database name for ibase_connect().
-      ;ibase.default_db =
-
-      ; Default username for ibase_connect().
-      ;ibase.default_user =
-
-      ; Default password for ibase_connect().
-      ;ibase.default_password =
-
-      ; Default charset for ibase_connect().
-      ;ibase.default_charset =
-
-      ; Default timestamp format.
-      ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
-
-      ; Default date format.
-      ibase.dateformat = "%Y-%m-%d"
-
-      ; Default time format.
-      ibase.timeformat = "%H:%M:%S"
-
       [MySQLi]
 
       ; Maximum number of persistent links.  -1 means no limit.
@@ -1559,10 +1539,6 @@ fpm:
       ; http://php.net/mysqli.max-links
       mysqli.max_links = -1
 
-      ; If mysqlnd is used: Number of cache slots for the internal result set cache
-      ; http://php.net/mysqli.cache_size
-      mysqli.cache_size = 2000
-
       ; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
       ; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
       ; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
@@ -1575,11 +1551,11 @@ fpm:
       ; http://php.net/mysqli.default-socket
       mysqli.default_socket =
 
-      ; Default host for mysql_connect() (doesn't apply in safe mode).
+      ; Default host for mysqli_connect() (doesn't apply in safe mode).
       ; http://php.net/mysqli.default-host
       mysqli.default_host =
 
-      ; Default user for mysql_connect() (doesn't apply in safe mode).
+      ; Default user for mysqli_connect() (doesn't apply in safe mode).
       ; http://php.net/mysqli.default-user
       mysqli.default_user =
 
@@ -1597,12 +1573,10 @@ fpm:
       [mysqlnd]
       ; Enable / Disable collection of general statistics by mysqlnd which can be
       ; used to tune and monitor MySQL operations.
-      ; http://php.net/mysqlnd.collect_statistics
       mysqlnd.collect_statistics = On
 
       ; Enable / Disable collection of memory usage statistics by mysqlnd which can be
       ; used to tune and monitor MySQL operations.
-      ; http://php.net/mysqlnd.collect_memory_statistics
       mysqlnd.collect_memory_statistics = Off
 
       ; Records communication from all extensions using mysqlnd to the specified log
@@ -1611,29 +1585,23 @@ fpm:
       ;mysqlnd.debug =
 
       ; Defines which queries will be logged.
-      ; http://php.net/mysqlnd.log_mask
       ;mysqlnd.log_mask = 0
 
       ; Default size of the mysqlnd memory pool, which is used by result sets.
-      ; http://php.net/mysqlnd.mempool_default_size
       ;mysqlnd.mempool_default_size = 16000
 
       ; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
-      ; http://php.net/mysqlnd.net_cmd_buffer_size
       ;mysqlnd.net_cmd_buffer_size = 2048
 
       ; Size of a pre-allocated buffer used for reading data sent by the server in
       ; bytes.
-      ; http://php.net/mysqlnd.net_read_buffer_size
       ;mysqlnd.net_read_buffer_size = 32768
 
       ; Timeout for network requests in seconds.
-      ; http://php.net/mysqlnd.net_read_timeout
       ;mysqlnd.net_read_timeout = 31536000
 
       ; SHA-256 Authentication Plugin related. File with the MySQL server public RSA
       ; key.
-      ; http://php.net/mysqlnd.sha256_server_public_key
       ;mysqlnd.sha256_server_public_key =
 
       [OCI8]
@@ -1761,10 +1729,11 @@ fpm:
       ;session.save_path = "/tmp"
 
       ; Whether to use strict session mode.
-      ; Strict session mode does not accept uninitialized session ID and regenerate
-      ; session ID if browser sends uninitialized session ID. Strict mode protects
-      ; applications from session fixation via session adoption vulnerability. It is
-      ; disabled by default for maximum compatibility, but enabling it is encouraged.
+      ; Strict session mode does not accept an uninitialized session ID, and
+      ; regenerates the session ID if the browser sends an uninitialized session ID.
+      ; Strict mode protects applications from session fixation via a session adoption
+      ; vulnerability. It is disabled by default for maximum compatibility, but
+      ; enabling it is encouraged.
       ; https://wiki.php.net/rfc/strict_sessions
       session.use_strict_mode = 0
 
@@ -1802,11 +1771,17 @@ fpm:
       ; http://php.net/session.cookie-domain
       session.cookie_domain =
 
-      ; Whether or not to add the httpOnly flag to the cookie, which makes it inaccessible to browser scripting languages such as JavaScript.
+      ; Whether or not to add the httpOnly flag to the cookie, which makes it
+      ; inaccessible to browser scripting languages such as JavaScript.
       ; http://php.net/session.cookie-httponly
       session.cookie_httponly =
 
-      ; Handler used to serialize data.  php is the standard serializer of PHP.
+      ; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
+      ; Current valid values are "Lax" or "Strict"
+      ; https://tools.ietf.org/html/draft-west-first-party-cookies-07
+      session.cookie_samesite =
+
+      ; Handler used to serialize data. php is the standard serializer of PHP.
       ; http://php.net/session.serialize-handler
       session.serialize_handler = php
 
@@ -1815,7 +1790,7 @@ fpm:
       ; gc_probability/gc_divisor. Where session.gc_probability is the numerator
       ; and gc_divisor is the denominator in the equation. Setting this value to 1
       ; when the session.gc_divisor value is 100 will give you approximately a 1% chance
-      ; the gc will run on any give request.
+      ; the gc will run on any given request.
       ; Default Value: 1
       ; Development Value: 1
       ; Production Value: 1
@@ -1825,10 +1800,10 @@ fpm:
       ; Defines the probability that the 'garbage collection' process is started on every
       ; session initialization. The probability is calculated by using the following equation:
       ; gc_probability/gc_divisor. Where session.gc_probability is the numerator and
-      ; session.gc_divisor is the denominator in the equation. Setting this value to 1
-      ; when the session.gc_divisor value is 100 will give you approximately a 1% chance
-      ; the gc will run on any give request. Increasing this value to 1000 will give you
-      ; a 0.1% chance the gc will run on any give request. For high volume production servers,
+      ; session.gc_divisor is the denominator in the equation. Setting this value to 100
+      ; when the session.gc_probability value is 1 will give you approximately a 1% chance
+      ; the gc will run on any given request. Increasing this value to 1000 will give you
+      ; a 0.1% chance the gc will run on any given request. For high volume production servers,
       ; this is a more efficient approach.
       ; Default Value: 100
       ; Development Value: 1000
@@ -1898,7 +1873,7 @@ fpm:
       session.trans_sid_tags = "a=href,area=href,frame=src,form="
 
       ; URL rewriter does not rewrite absolute URLs by default.
-      ; To enable rewrites for absolute pathes, target hosts must be specified
+      ; To enable rewrites for absolute paths, target hosts must be specified
       ; at RUNTIME. i.e. use ini_set()
       ; <form> tags is special. PHP will check action attribute's URL regardless
       ; of session.trans_sid_tags setting.
@@ -1987,7 +1962,7 @@ fpm:
       ; http://php.net/assert.active
       ;assert.active = On
 
-      ; Throw an AssertationException on failed assertions
+      ; Throw an AssertionError on failed assertions
       ; http://php.net/assert.exception
       ;assert.exception = On
 
@@ -2017,7 +1992,7 @@ fpm:
       ; http://php.net/com.allow-dcom
       ;com.allow_dcom = true
 
-      ; autoregister constants of a components typlib on com_load()
+      ; autoregister constants of a component's typlib on com_load()
       ; http://php.net/com.autoregister-typelib
       ;com.autoregister_typelib = true
 
@@ -2048,9 +2023,9 @@ fpm:
 
       ; Use of this INI entry is deprecated, use global input_encoding instead.
       ; http input encoding.
-      ; mbstring.encoding_traslation = On is needed to use this setting.
+      ; mbstring.encoding_translation = On is needed to use this setting.
       ; If empty, default_charset or input_encoding or mbstring.input is used.
-      ; The precedence is: default_charset < intput_encoding < mbsting.http_input
+      ; The precedence is: default_charset < input_encoding < mbsting.http_input
       ; http://php.net/mbstring.http-input
       ;mbstring.http_input =
 
@@ -2101,6 +2076,16 @@ fpm:
       ; is activated.
       ; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
       ;mbstring.http_output_conv_mimetype=
+
+      ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
+      ; to the pcre.recursion_limit for PCRE.
+      ; Default: 100000
+      ;mbstring.regex_stack_limit=100000
+
+      ; This directive specifies maximum retry count for mbstring regular expressions. It is similar
+      ; to the pcre.backtrack_limit for PCRE.
+      ; Default: 1000000
+      ;mbstring.regex_retry_limit=1000000
 
       [gd]
       ; Tell the jpeg decode to ignore warnings and try to create
@@ -2169,17 +2154,6 @@ fpm:
       ; Sets the maximum number of open links or -1 for unlimited.
       ldap.max_links = -1
 
-      [mcrypt]
-      ; For more information about mcrypt settings see http://php.net/mcrypt-module-open
-
-      ; Directory where to load mcrypt algorithms
-      ; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
-      ;mcrypt.algorithms_dir=
-
-      ; Directory where to load mcrypt modes
-      ; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
-      ;mcrypt.modes_dir=
-
       [dba]
       ;dba.default_handler=
 
@@ -2225,18 +2199,13 @@ fpm:
       ; size of the optimized code.
       ;opcache.save_comments=1
 
-      ; If enabled, a fast shutdown sequence is used for the accelerated code
-      ; Depending on the used Memory Manager this may cause some incompatibilities.
-      ;opcache.fast_shutdown=0
-
       ; Allow file existence override (file_exists, etc.) performance feature.
       ;opcache.enable_file_override=0
 
       ; A bitmask, where each bit enables or disables the appropriate OPcache
       ; passes
-      ;opcache.optimization_level=0xffffffff
+      ;opcache.optimization_level=0x7FFFBFFF
 
-      ;opcache.inherited_hack=1
       ;opcache.dups_fix=0
 
       ; The location of the OPcache blacklist file (wildcards allowed).
@@ -2285,6 +2254,10 @@ fpm:
       ; errors.
       ;opcache.mmap_base=
 
+      ; Facilitates multiple OPcache instances per user (for Windows only). All PHP
+      ; processes with the same cache ID and user share an OPcache instance.
+      ;opcache.cache_id=
+
       ; Enables and sets the second level cache directory.
       ; It should improve performance when SHM memory is full, at server restart or
       ; SHM reset. The default "" disables file based caching.
@@ -2315,6 +2288,24 @@ fpm:
       ; optimizations.
       ;opcache.opt_debug_level=0
 
+      ; Specifies a PHP script that is going to be compiled and executed at server
+      ; start-up.
+      ; http://php.net/opcache.preload
+      ;opcache.preload=
+
+      ; Preloading code as root is not allowed for security reasons. This directive
+      ; facilitates to let the preloading to be run as another user.
+      ; http://php.net/opcache.preload_user
+      ;opcache.preload_user=
+
+      ; Prevents caching files that are less than this number of seconds old. It
+      ; protects from caching of incompletely updated files. In case all file updates
+      ; on your site are atomic, you may increase performance by setting it to "0".
+      ;opcache.file_update_protection=2
+
+      ; Absolute path used to store shared lockfiles (for *nix only).
+      ;opcache.lockfile_path=/tmp
+
       [curl]
       ; A default value for the CURLOPT_CAINFO option. This is required to be an
       ; absolute path.
@@ -2338,9 +2329,15 @@ fpm:
       ; SSL stream context option.
       ;openssl.capath=
 
-      ; Local Variables:
-      ; tab-width: 4
-      ; End:
+      [ffi]
+      ; FFI API restriction. Possible values:
+      ; "preload" - enabled in CLI scripts and preloaded files (default)
+      ; "false"   - always disabled
+      ; "true"    - always enabled
+      ;ffi.enable=preload
+
+      ; List of headers files to preload, wildcard patterns allowed.
+      ;ffi.preload=
 
     php-fpm.conf: |
       ;;;;;;;;;;;;;;;;;;;;;
@@ -2366,7 +2363,7 @@ fpm:
       ; into a local file.
       ; Note: the default prefix is /usr/local/var
       ; Default Value: log/php-fpm.log
-      error_log = /dev/stderr
+      error_log = /proc/self/fd/2
 
       ; syslog_facility is used to specify what type of program is logging the
       ; message. This lets syslogd specify that messages from different facilities
@@ -2384,13 +2381,31 @@ fpm:
       ; Log level
       ; Possible Values: alert, error, warning, notice, debug
       ; Default Value: notice
-      log_level = notice
+      ;log_level = notice
+
+      ; Log limit on number of characters in the single line (log entry). If the
+      ; line is over the limit, it is wrapped on multiple lines. The limit is for
+      ; all logged characters including message prefix and suffix if present. However
+      ; the new line character does not count into it as it is present only when
+      ; logging to a file descriptor. It means the new line character is not present
+      ; when logging to syslog.
+      ; Default Value: 1024
+      log_limit = 4096
+
+      ; Log buffering specifies if the log line is buffered which means that the
+      ; line is written in a single write operation. If the value is false, then the
+      ; data is written directly into the file descriptor. It is an experimental
+      ; option that can potentionaly improve logging performance and memory usage
+      ; for some heavy logging scenarios. This option is ignored if logging to syslog
+      ; as it has to be always buffered.
+      ; Default value: yes
+      ;log_buffering = no
 
       ; If this number of child processes exit with SIGSEGV or SIGBUS within the time
       ; interval set by emergency_restart_interval then FPM will restart. A value
       ; of '0' means 'Off'.
       ; Default Value: 0
-      emergency_restart_threshold = 0
+      ;emergency_restart_threshold = 0
 
       ; Interval of time used by emergency_restart_interval to determine when
       ; a graceful restart will be initiated.  This can be useful to work around
@@ -2398,7 +2413,7 @@ fpm:
       ; Available Units: s(econds), m(inutes), h(ours), or d(ays)
       ; Default Unit: seconds
       ; Default Value: 0
-      emergency_restart_interval = 0
+      ;emergency_restart_interval = 0
 
       ; Time limit for child processes to wait for a reaction on signals from master.
       ; Available units: s(econds), m(inutes), h(ours), or d(ays)
@@ -2494,7 +2509,7 @@ fpm:
         ; Note: The user is mandatory. If the group is not set, the default user's group
         ;       will be used.
         user = nobody
-        group = nobody
+        group = nogroup
 
         ; The address on which to accept FastCGI requests.
         ; Valid syntaxes are:
@@ -2518,8 +2533,9 @@ fpm:
         ; Default Values: user and group are set as the running user
         ;                 mode is set to 0660
         listen.owner = nobody
-        listen.group = nobody
+        listen.group = nogroup
         listen.mode = 0660
+
         ; When POSIX Access Control Lists are supported you can set them using
         ; these options, value is a comma separated list of user/group names.
         ; When set, listen.owner and listen.group are ignored
@@ -2587,7 +2603,7 @@ fpm:
 
         ; The number of child processes created on startup.
         ; Note: Used only when pm is set to 'dynamic'
-        ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+        ; Default Value: (min_spare_servers + max_spare_servers) / 2
         ;pm.start_servers = 2
 
         ; The desired minimum number of idle server processes.
@@ -2609,7 +2625,7 @@ fpm:
         ; This can be useful to work around memory leaks in 3rd party libraries. For
         ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
         ; Default Value: 0
-        pm.max_requests = 500
+        ;pm.max_requests = 500
 
         ; The URI to view the FPM status page. If this value is not set, no URI will be
         ; recognized as a status page. It shows the following informations:
@@ -2708,7 +2724,7 @@ fpm:
         ;       anything, but it may not be a good idea to use the .php extension or it
         ;       may conflict with a real PHP file.
         ; Default Value: not set
-        ;pm.status_path = /statu
+        pm.status_path = /status
 
         ; The ping URI to call the monitoring page of FPM. If this value is not set, no
         ; URI will be recognized as a ping page. This could be used to test from outside
@@ -2801,12 +2817,24 @@ fpm:
         ; Default Value: 0
         ;request_slowlog_timeout = 0
 
+        ; Depth of slow log stack trace.
+        ; Default Value: 20
+        ;request_slowlog_trace_depth = 20
+
         ; The timeout for serving a single request after which the worker process will
         ; be killed. This option should be used when the 'max_execution_time' ini option
         ; does not stop script execution for some reason. A value of '0' means 'off'.
         ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
         ; Default Value: 0
-        request_terminate_timeout = 0
+        ;request_terminate_timeout = 0
+
+        ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
+        ; application calls 'fastcgi_finish_request' or when application has finished and
+        ; shutdown functions are being called (registered via register_shutdown_function).
+        ; This option will enable timeout limit to be applied unconditionally
+        ; even in such cases.
+        ; Default Value: no
+        ;request_terminate_timeout_track_finished = no
 
         ; Set open file descriptor rlimit.
         ; Default Value: system defined value
@@ -2839,6 +2867,13 @@ fpm:
         ; process time (several ms).
         ; Default Value: no
         catch_workers_output = yes
+
+        ; Decorate worker output with prefix and suffix containing information about
+        ; the child that writes to the log and if stdout or stderr is used as well as
+        ; log level and time. This options is used only if catch_workers_output is yes.
+        ; Settings to "no" will output data as written to the stdout or stderr.
+        ; Default value: yes
+        decorate_workers_output = no
 
         ; Clear environment in FPM workers
         ; Prevents arbitrary environment variables from reaching FPM worker processes


### PR DESCRIPTION
Upgrade dependent container versions.

- nginx v1.15.1 -> 1.17
- php-fpm v7.1 -> 7.4
    - Update `php.ini`, `php-fpm.conf`, `www.conf`
    - Description of PHP-FPM log option added from v7.3

#### Checklist

- [X] Chart Version bumped


