### PR TITLE
version up v9.6.1.256 => v9.7.0.258

### DIFF
--- a/newrelic-php-agent/Chart.yaml
+++ b/newrelic-php-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Newrelic PHP Agent
 name: newrelic-php-agent
-version: 0.3.0
-appVersion: "9.6.1.256"
+version: 0.4.0
+appVersion: "9.7.0.258"

--- a/newrelic-php-agent/values.yaml
+++ b/newrelic-php-agent/values.yaml
@@ -8,7 +8,7 @@ newrelic:
 
 image:
   repository: chatwork/newrelic-php-agent
-  tag: 9.6.1.256
+  tag: 9.7.0.258
   pullPolicy: IfNotPresent
   command: []
   pullSecrets: []


### PR DESCRIPTION
#### Description
Newrelic's PHP Agent version 9.7.0.258 has been released, so it corresponds
https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-970258

#### Checklist

- [x] Chart Version bumped


