### PR TITLE
[postfix] supports lifecycle injection

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: 3.4.8
 description: Postfix Helm Chart
 name: postfix
-version: 0.7.0
+version: 0.8.0

--- a/postfix/templates/daemonset.yaml
+++ b/postfix/templates/daemonset.yaml
@@ -31,10 +31,7 @@ spec:
         {{- with .Values.resources }}
         resources: {{ toYaml . | nindent 12 }}
         {{- end }}
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/sbin/postfix", "flush"]
+        lifecycle: {{ toYaml .Values.preStop | nindent 10 }}
         ports:
           - name: smtp
             containerPort: 25

--- a/postfix/templates/deployment.yaml
+++ b/postfix/templates/deployment.yaml
@@ -31,10 +31,7 @@ spec:
         {{- with .Values.resources }}
         resources: {{ toYaml . | nindent 12 }}
         {{- end }}
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/sbin/postfix", "flush"]
+        lifecycle: {{ toYaml .Values.preStop | nindent 10 }}
         ports:
         - name: smtp
           containerPort: 25

--- a/postfix/templates/statefulset.yaml
+++ b/postfix/templates/statefulset.yaml
@@ -28,10 +28,7 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/usr/sbin/postfix", "flush"]
+          lifecycle: {{ toYaml .Values.preStop | nindent 10 }}
           ports:
             - name: smtp
               containerPort: 25

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -55,6 +55,10 @@ daemonset:
 
   hostPort: 25
 
+  lifecycle:
+    preStop:
+      command: ["/usr/sbin/postfix", "flush"]
+
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   #updateStrategy: RollingUpdate
 
@@ -73,6 +77,10 @@ deployment:
       maxSurge: 1
       maxUnavailable: 0
 
+  lifecycle:
+    preStop:
+      command: ["/usr/sbin/postfix", "flush"]
+
   podAnnotations: {}
   affinity: {}
   tolerations: []
@@ -86,6 +94,10 @@ statefulSet:
   enabled: false
 
   replicas: 1
+
+  lifecycle:
+    preStop:
+      command: ["/usr/sbin/postfix", "flush"]
 
   podAnnotations: {}
   affinity: {}


### PR DESCRIPTION
Lifecycle can be injected because we want to add a waiting time after flushing `preStop`.

#### Checklist

- [X] Chart Version bumped


