### PR TITLE
[php] fixes tpl expansion of annotations

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.17.0
+version: 0.17.1
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/templates/configmap-busybox.yaml
+++ b/php/templates/configmap-busybox.yaml
@@ -7,7 +7,10 @@ metadata:
   name: {{ template "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
   labels: {{ include "php.labels" $root | nindent 4 }}
   {{- with $root.Values.busybox.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -7,7 +7,10 @@ metadata:
   name: {{ template "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
   labels: {{ include "php.labels" $root | nindent 4 }}
   {{- with $root.Values.fpm.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}

--- a/php/templates/configmap-nginx.yaml
+++ b/php/templates/configmap-nginx.yaml
@@ -7,7 +7,10 @@ metadata:
   name: {{ template "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
   labels: {{ include "php.labels" $root | nindent 4 }}
   {{- with $root.Values.nginx.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         checksum/secret-busybox: {{ include (print $.Template.BasePath "/secret-busybox.yaml") . | sha256sum }}
         checksum/secret-fpm: {{ include (print $.Template.BasePath "/secret-fpm.yaml") . | sha256sum }}
         checksum/secret-nginx: {{ include (print $.Template.BasePath "/secret-nginx.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
-        {{- tpl (toYaml .) $root | nindent 8 }}
+        {{- range $k, $v := .Values.podAnnotations }}
+        {{ $k }}: {{ tpl $v $root | toYaml | indent 8 }}
         {{- end }}
     spec:
       {{- if .Values.busybox.enabled }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -6,7 +6,10 @@ metadata:
   name: {{ template "php.fullname" . }}
   labels: {{ include "php.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
-  annotations: {{ tpl (toYaml .) $root | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   backend:

--- a/php/templates/secret-busybox.yaml
+++ b/php/templates/secret-busybox.yaml
@@ -7,7 +7,10 @@ metadata:
   name: {{ template "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
   labels: {{ include "php.labels" $root | nindent 4 }}
   {{- with $root.Values.busybox.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/php/templates/secret-fpm.yaml
+++ b/php/templates/secret-fpm.yaml
@@ -7,7 +7,10 @@ metadata:
   name: {{ template "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
   labels: {{ include "php.labels" $root | nindent 4 }}
   {{- with $root.Values.fpm.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/php/templates/secret-nginx.yaml
+++ b/php/templates/secret-nginx.yaml
@@ -7,7 +7,10 @@ metadata:
   name: {{ template "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
   labels: {{ include "php.labels" $root | nindent 4 }}
   {{- with $root.Values.nginx.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/php/templates/service.yaml
+++ b/php/templates/service.yaml
@@ -5,7 +5,10 @@ metadata:
   name: {{ template "php.fullname" . }}
   labels: {{ include "php.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
-  annotations: {{ tpl (toYaml .) $root | nindent 4 }}
+  annotations:
+    {{- range $k, $v := . }}
+    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
https://github.com/helm/helm/issues/7704
In go-yaml used by helm, space is broken on lines that exceed `80` characters.
This has the problem of breaking the go template.

So, I changed to do `toYaml` after `tpl` expansion of annotations.

#### Checklist

- [X] Chart Version bumped


