### PR TITLE
add fluent-bit

### DIFF
--- a/fluent-bit/.helmignore
+++ b/fluent-bit/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/fluent-bit/Chart.yaml
+++ b/fluent-bit/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fluent-bit
+description: Fast and Lightweight Log processor and forwarder
+type: application
+version: 0.1.0
+appVersion: 1.3.11

--- a/fluent-bit/Makefile
+++ b/fluent-bit/Makefile
@@ -1,0 +1,15 @@
+.PHONY: apply
+apply:
+	@if ! kubectl get namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" >/dev/null 2>&1; then \
+		kubectl create namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)"; \
+	fi
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --force --wait --install --namespace "$$(basename $$PWD)$$(git rev-parse --short HEAD)" $$(basename $$PWD)-$$(git rev-parse --short HEAD) .;
+
+.PHONY: test
+test:
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} test $$(basename $$PWD)-$$(git rev-parse --short HEAD)
+
+.PHONY: delete
+delete:
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} ls -q \
+		| xargs -I {} helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} delete --purge $$(basename $$PWD)-$$(git rev-parse --short HEAD);

--- a/fluent-bit/README.md
+++ b/fluent-bit/README.md
@@ -10,7 +10,7 @@ $ helm install chatwork/fluent-bit
 
 ## Prerequisites
 
-* Kubernetes 1.11+
+* Kubernetes 1.14+
 
 ## Installing the Chart
 

--- a/fluent-bit/README.md
+++ b/fluent-bit/README.md
@@ -1,0 +1,60 @@
+# Fluent Bit
+
+[Fluent Bit](https://fluentbit.io/) is fast and lightweight log processor and forwarder.
+
+## TL;DR;
+
+```
+$ helm install chatwork/fluent-bit
+```
+
+## Prerequisites
+
+* Kubernetes 1.11+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install --name my-release chatwork/fluent-bit
+```
+
+The command deploys the slime chart on the Kubernetes cluster in the default configuration. The [configuration](https://github.com/chatwork/charts/tree/master/fluent-bit#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall the `my-release` deployment:
+
+```
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the slime chart and their default values.
+
+|  Parameter | Description | Default |
+| --- | --- | --- |
+| `image.repository` | The image repository to pull from | `"fluent/fluent-bit` |
+| `image.pullPolicy` | Image pull policy | `"IfNotPresent` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+| `nameOverride` | Override name of app | `""` |
+| `fullnameOverride` | Override full name of app | `""` |
+| `podAnnotations` | Annotations to be added to pods | `{}` |
+| `serviceAccount.create` | If true, create a service account for the pod | `false` |
+| `serviceAccount.annotations` | Annotations for the created service account | `{}` |
+| `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `nil` |
+| `rbac.create` | If true, create & use RBAC resources | `false` |
+| `podSecurityContext` | Security context policies to add to the controller pod | `{}` |
+| `securityContext` | Allows you to overwrite the default securityContext applied to the container | `{}` |
+| `env` | Extra environment variables that will be passed onto pods | `{}` |
+| `resources` | Pod resource requests & limits | `{}` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `tolerations` | Node taints to tolerate | `[]` |
+| `affinity` | Node/Pod affinities | `{}` |
+| `metrics.enabled` | If true, enable Prometheus metrics | `false` |
+| `configmaps` | Configuration file to be mounted under /fluent-bit/etc | `{"fluent-bit.conf":"..."}` |
+| `secrets` | Secret information file to be mounted under /secure | `{}` |

--- a/fluent-bit/templates/NOTES.txt
+++ b/fluent-bit/templates/NOTES.txt
@@ -1,0 +1,1 @@
+fluent-bit is now running.

--- a/fluent-bit/templates/_helpers.tpl
+++ b/fluent-bit/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluent-bit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluent-bit.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluent-bit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "fluent-bit.labels" -}}
+helm.sh/chart: {{ include "fluent-bit.chart" . }}
+{{ include "fluent-bit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fluent-bit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC APIs.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fluent-bit.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "fluent-bit.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/fluent-bit/templates/cluster-role.yaml
+++ b/fluent-bit/templates/cluster-role.yaml
@@ -11,4 +11,12 @@ rules:
       - pods
     verbs:
       - get
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "fluent-bit.fullname" . }}
+    verbs:
+      - use
 {{- end }}

--- a/fluent-bit/templates/cluster-role.yaml
+++ b/fluent-bit/templates/cluster-role.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  labels: {{ include "fluent-bit.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+{{- end }}

--- a/fluent-bit/templates/cluster-rolebinding.yaml
+++ b/fluent-bit/templates/cluster-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  labels: {{ include "fluent-bit.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "fluent-bit.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "fluent-bit.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/fluent-bit/templates/configmap.yaml
+++ b/fluent-bit/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- $root := . -}}
+{{- range $name, $tmpl := .Values.configmaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fluent-bit.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+  labels: {{ include "fluent-bit.labels" $root | nindent 4 }}
+data:
+  {{ $name }}: |
+{{ tpl $tmpl $root | indent 4 }}
+{{- end }}

--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -1,0 +1,89 @@
+{{- $root := . -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  labels: {{ include "fluent-bit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{ include "fluent-bit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "fluent-bit.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.metrics.enabled }}
+          ports:
+          - name: metrics
+            containerPort: 2020
+            protocol: TCP
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            {{- range $name, $tmpl := .Values.configmaps }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /fluent-bit/etc/{{ $name }}
+              subPath: {{ $name }}
+            {{- end }}
+            {{- range $name, $secret := .Values.secrets }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /secure/{{ $name }}
+              subPath: {{ $name }}
+            {{- end }}
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        {{- range $name, $tmpl := .Values.configmaps }}
+        - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+          configMap:
+            name: {{ include "fluent-bit.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+        {{- end }}
+        {{- range $name, $secrets := .Values.secrets }}
+        - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+          secret:
+            secretName: {{ include "fluent-bit.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}

--- a/fluent-bit/templates/psp.yaml
+++ b/fluent-bit/templates/psp.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.rbac.create }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'hostPath'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/fluent-bit/templates/secret.yaml
+++ b/fluent-bit/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- $root := . -}}
+{{- range $name, $secret := .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fluent-bit.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+  labels: {{ include "fluent-bit.labels" $root | nindent 4 }}
+type: Opaque
+data:
+  {{ $name }}: {{ tpl $secret $root | b64enc | quote }}
+{{- end }}

--- a/fluent-bit/templates/serviceaccount.yaml
+++ b/fluent-bit/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fluent-bit.serviceAccountName" . }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -1,0 +1,99 @@
+# Default values for fluent-bit.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: fluent/fluent-bit
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  # Specifies whether a role & rolebinding should be created
+  create: false
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+env: {}
+  #- name: FOO
+  #  value: "Hello World"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+metrics:
+  # Enable HTTP endpoint to return metrics with fluent bit
+  enabled: false
+
+configmaps:
+  # Define fluent-bit configuration files such as fluent-bit.conf and parsers.conf.
+  # These are mounted under /fluent-bit/etc/.
+  fluent-bit.conf: |-
+    [SERVICE]
+        Flush          1
+        Daemon         Off
+        Log_Level      info
+        Parsers_File   parsers.conf
+        {{- if .Values.metrics.enabled }}
+        HTTP_Server  On
+        HTTP_Listen  0.0.0.0
+        HTTP_Port    2020
+       {{- end }}
+    [INPUT]
+        Name           tail
+        Tag            kube.*
+        Path           /var/log/containers/*.log
+        Parser         docker
+        DB             /var/log/flb_kube.db
+        Mem_Buf_Limit  5MB
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        Kube_URL       https://kubernetes.default.svc:443
+        Merge_JSON_Log On
+    [OUTPUT]
+        Name            stdout
+        Match           *
+
+secrets: {}
+  # Define secret information used in fluent-bit such as google_service_credentials.json.
+  # These are mounted under /secure.
+  # google_service_credentials.json: |
+  #   ...


### PR DESCRIPTION
I made a helm chart of [Fluent Bit](https://fluentbit.io/).
There is a [stable/fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit), but it is difficult to support BigQuery, CloudWatch and S3, so I decided to create a new one.

#### Checklist

- [x] Chart Version bumped