### PR TITLE
[elasticsearch] add Elasticsearch chart

### DIFF
--- a/elasticsearch/.helmignore
+++ b/elasticsearch/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Elasticsearch
+name: elasticsearch
+version: 0.1.0

--- a/elasticsearch/Makefile
+++ b/elasticsearch/Makefile
@@ -1,0 +1,18 @@
+NAMESPACE := $$(basename $$PWD)$$(git rev-parse --short HEAD)
+RELEASE := $$(basename $$PWD)-$$(git rev-parse --short HEAD)
+
+.PHONY: apply
+apply:
+	@if ! kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1; then \
+		kubectl create namespace "${NAMESPACE}"; \
+	fi
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} upgrade --wait --install --namespace "${NAMESPACE}" "${RELEASE}" .;
+
+.PHONY: test
+test:
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} test "${RELEASE}"
+
+.PHONY: delete
+delete:
+	helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} ls -q \
+		| xargs -I {} helm --kube-context $${KUBE_CONTEXT:-"dind"} --tiller-namespace $${TILLER_NAMESPACE:-"kube-system"} delete --purge "${RELEASE}";

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elasticsearch.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticsearch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/elasticsearch/templates/configmap.yaml
+++ b/elasticsearch/templates/configmap.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ template "elasticsearch.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    checksum/elasticsearch_yml: {{ tpl .Values.elasticsearch.config . | sha256sum }}
+data:
+  elasticsearch_conf: |
+{{ tpl .Values.elasticsearch.config . | indent 4 }}

--- a/elasticsearch/templates/deployment.yaml
+++ b/elasticsearch/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ template "elasticsearch.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "elasticsearch.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/elasticsearch_conf: {{ tpl .Values.elasticsearch.config . | sha256sum }}
+    spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
+{{- with .Values.initContainers }}
+      initContainers:
+{{ toYaml . | indent 6 }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: elasticsearch
+              containerPort: {{ .Values.elasticsearch.port }}
+              protocol: TCP
+          env:
+{{- with .Values.elasticsearch.discoveryType }}
+          - name: discovery.type
+            value: {{ . }}
+{{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.elasticsearch.port }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.elasticsearch.port }}
+          volumeMounts:
+            - name: conf
+              subPath: elasticsearch_conf
+              mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+      volumes:
+        - name: conf
+          configMap:
+            name: {{ template "elasticsearch.fullname" . }}
+{{- with .Values.extraVolumes }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/elasticsearch/templates/service.yaml
+++ b/elasticsearch/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ template "elasticsearch.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.elasticsearch.port }}
+      protocol: TCP
+      name: elasticsearch
+  selector:
+    app: {{ template "elasticsearch.name" . }}
+    release: {{ .Release.Name }}

--- a/elasticsearch/templates/test/test-pod.yaml
+++ b/elasticsearch/templates/test/test-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}-test
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ template "elasticsearch.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    role: test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: {{ .Chart.Name }}-test
+      image: "chatwork/aws"
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -c
+        - |
+          curl --fail "http://{{ template "elasticsearch.fullname" . }}:{{ .Values.service.port }}/_cluster/health?wait_for_status=green&timeout=1s"
+  restartPolicy: Never

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -1,0 +1,46 @@
+# Default values for elasticsearch.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: docker.elastic.co/elasticsearch/elasticsearch
+  tag: 7.1.1
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+initContainers: []
+
+service:
+  type: ClusterIP
+  port: 9200
+
+elasticsearch:
+  port: 9200
+  discoveryType: single-node
+  config: |
+    network.host: 0.0.0.0
+
+extraVolumeMounts: []
+#  - name: data
+#    mountPath: /data
+
+extraVolumes: []
+#  - name: data
+#    emptyDir: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This PR is that added an Elasticsearch Chart.
This chart implements only the minimum functionality needed to use Elasticsearch for development and testing (including CI).

#### Checklist

- [x] Chart Version bumped


