### PR TITLE
[fluent-bit] add command

### DIFF
--- a/fluent-bit/Chart.yaml
+++ b/fluent-bit/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fluent-bit
 description: Fast and Lightweight Log processor and forwarder
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 1.3.11

--- a/fluent-bit/README.md
+++ b/fluent-bit/README.md
@@ -41,6 +41,7 @@ The following table lists the configurable parameters of the slime chart and the
 | `image.repository` | The image repository to pull from | `"fluent/fluent-bit` |
 | `image.pullPolicy` | Image pull policy | `"IfNotPresent` |
 | `imagePullSecrets` | Image pull secrets | `[]` |
+| `command` | Additional command arguments | `[]` |
 | `nameOverride` | Override name of app | `""` |
 | `fullnameOverride` | Override full name of app | `""` |
 | `podAnnotations` | Annotations to be added to pods | `{}` |

--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -30,6 +30,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -10,6 +10,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+command: []
+
 podAnnotations: {}
 
 serviceAccount:


### PR DESCRIPTION
For example, the extension of the command is necessary in the use case of a plugin as shown below.

```
$ /fluent-bit/bin/fluent-bit -e out_s3.so -c /fluent-bit/etc/fluent-bit.conf
```

#### Checklist

- [X] Chart Version bumped


