### PR TITLE
Add priorityClassName to fluent-bit

### DIFF
--- a/fluent-bit/Chart.yaml
+++ b/fluent-bit/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fluent-bit
 description: Fast and Lightweight Log processor and forwarder
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.3.11

--- a/fluent-bit/README.md
+++ b/fluent-bit/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the slime chart and the
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Node taints to tolerate | `[]` |
 | `affinity` | Node/Pod affinities | `{}` |
+| `priorityClassName` | Priority Class Name | `""` |
 | `metrics.enabled` | If true, enable Prometheus metrics | `false` |
 | `configmaps` | Configuration file to be mounted under /fluent-bit/etc | `{"fluent-bit.conf":"..."}` |
 | `secrets` | Secret information file to be mounted under /secure | `{}` |

--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
           {{- with .Values.command }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -15,6 +15,8 @@ command: []
 
 podAnnotations: {}
 
+priorityClassName: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
#### Changes

- Add `priorityClassName` to fluent-bit chart
   - https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

#### Checklist

- [x] Chart Version bumped


