### PR TITLE
[postfix] support metrics

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 3.4.8
 description: Postfix Helm Chart
 name: postfix
-version: 0.8.1
+version: 0.9.0

--- a/postfix/templates/daemonset.yaml
+++ b/postfix/templates/daemonset.yaml
@@ -47,8 +47,6 @@ spec:
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
-          - name: varlog
-            mountPath: /var/log
           {{- range $k, $v := .Values.postfix.templates }}
           - name: configmap
             subPath: {{ $k }}
@@ -90,9 +88,9 @@ spec:
           subPath: {{ .Values.persistence.subPath }}
           {{- end }}
           readOnly: true
-        - name: varlog
-          mountPath: /var/log
-          readOnly: true
+        {{- if .Values.extraVolumeMounts }}
+        {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
+        {{- end }}
       {{- end }}
       volumes:
         - name: spool
@@ -102,8 +100,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-        - name: varlog
-          emptyDir: {}
         - name: configmap
           configMap:
             name: {{ template "postfix.fullname" . }}-configmap

--- a/postfix/templates/daemonset.yaml
+++ b/postfix/templates/daemonset.yaml
@@ -47,6 +47,8 @@ spec:
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
+          - name: varlog
+            mountPath: /var/log
           {{- range $k, $v := .Values.postfix.templates }}
           - name: configmap
             subPath: {{ $k }}
@@ -61,6 +63,37 @@ spec:
           {{- if .Values.extraVolumeMounts }}
           {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
           {{- end }}
+      {{- if .Values.metrics.enabled }}
+      - name: exporter
+        image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+        {{- with .Values.metrics.command }}
+        command: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.metrics.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.metrics.port }}
+          protocol: TCP
+        {{- with .Values.metrics.livenessProbe }}
+        livenessProbe: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.metrics.readinessProbe }}
+        readinessProbe: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: spool
+          mountPath: /var/spool/postfix
+          {{- if .Values.persistence.subPath }}
+          subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+      {{- end }}
       volumes:
         - name: spool
           {{- if .Values.persistence.enabled }}
@@ -69,6 +102,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: varlog
+          emptyDir: {}
         - name: configmap
           configMap:
             name: {{ template "postfix.fullname" . }}-configmap

--- a/postfix/templates/deployment.yaml
+++ b/postfix/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
+          - name: varlog
+            mountPath: /var/log
           {{- range $k, $v := .Values.postfix.templates }}
           - name: configmap
             subPath: {{ $k }}
@@ -58,6 +60,37 @@ spec:
           {{- if .Values.extraVolumeMounts }}
           {{ toYaml .Values.extraVolumeMounts . | nindent 10 }}
           {{- end }}
+      {{- if .Values.metrics.enabled }}
+      - name: exporter
+        image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+        {{- with .Values.metrics.command }}
+        command: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.metrics.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        ports:
+          - name: http
+            containerPort: {{ .Values.metrics.port }}
+            protocol: TCP
+        {{- with .Values.metrics.livenessProbe }}
+        livenessProbe: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.metrics.readinessProbe }}
+        readinessProbe: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+          - name: spool
+            mountPath: /var/spool/postfix
+            {{- if .Values.persistence.subPath }}
+            subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
+            readOnly: true
+          - name: varlog
+            mountPath: /var/log
+            readOnly: true
+      {{- end }}
       volumes:
         - name: spool
           {{- if .Values.persistence.enabled }}
@@ -66,6 +99,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: varlog
+          emptyDir: {}
         - name: configmap
           configMap:
             name: {{ template "postfix.fullname" . }}-configmap

--- a/postfix/templates/deployment.yaml
+++ b/postfix/templates/deployment.yaml
@@ -44,8 +44,6 @@ spec:
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
-          - name: varlog
-            mountPath: /var/log
           {{- range $k, $v := .Values.postfix.templates }}
           - name: configmap
             subPath: {{ $k }}
@@ -87,9 +85,9 @@ spec:
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
             readOnly: true
-          - name: varlog
-            mountPath: /var/log
-            readOnly: true
+        {{- if .Values.extraVolumeMounts }}
+        {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
+        {{- end }}
       {{- end }}
       volumes:
         - name: spool
@@ -99,8 +97,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-        - name: varlog
-          emptyDir: {}
         - name: configmap
           configMap:
             name: {{ template "postfix.fullname" . }}-configmap

--- a/postfix/templates/statefulset.yaml
+++ b/postfix/templates/statefulset.yaml
@@ -42,6 +42,8 @@ spec:
               {{- with .Values.persistence.subPath }}
               subPath: {{ . }}
               {{- end }}
+            - name: varlog
+              mountPath: /var/log
             {{- range $k, $v := .Values.postfix.templates }}
             - name: configmap
               subPath: {{ $k }}
@@ -55,7 +57,40 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts . | nindent 10 }}
             {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: exporter
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          {{- with .Values.metrics.command }}
+          command: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.metrics.resources }}
+          resources: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+          {{- with .Values.metrics.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.metrics.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          volumeMounts:
+            - name: spool
+              mountPath: /var/spool/postfix
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+        {{- end }}
       volumes:
+        - name: varlog
+          emptyDir: {}
         - name: configmap
           configMap:
             name: {{ template "postfix.fullname" . }}-configmap

--- a/postfix/templates/statefulset.yaml
+++ b/postfix/templates/statefulset.yaml
@@ -42,8 +42,6 @@ spec:
               {{- with .Values.persistence.subPath }}
               subPath: {{ . }}
               {{- end }}
-            - name: varlog
-              mountPath: /var/log
             {{- range $k, $v := .Values.postfix.templates }}
             - name: configmap
               subPath: {{ $k }}
@@ -84,13 +82,11 @@ spec:
               subPath: {{ .Values.persistence.subPath }}
               {{- end }}
               readOnly: true
-            - name: varlog
-              mountPath: /var/log
-              readOnly: true
+            {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
+            {{- end }}
         {{- end }}
       volumes:
-        - name: varlog
-          emptyDir: {}
         - name: configmap
           configMap:
             name: {{ template "postfix.fullname" . }}-configmap

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -806,6 +806,20 @@ postfix:
     # sasl_passwd: |-
     #   [smtp.sendgrid.net]:587 yourSendGridUsername:yourSendGridPassword
 
+metrics:
+  enabled: false
+  image:
+    repository: chatwork/kumina-postfix-exporter
+    tag: k-kinzal-fixes-panic-logfilepath-empty
+    pullPolicy: IfNotPresent
+  command:
+    - /bin/postfix_exporter
+    - --postfix.logfile_path=""
+  port: 9154
+  resources: {}
+  livenessProbe: {}
+  readinessProbe: {}
+
 # for helm test
 test:
   # helm test でテスト送信する宛先


### PR DESCRIPTION
Added exporter so that postfix chart can get metrics.
By default, [kumina-postfix-exporter](https://github.com/kumina/postfix_exporter) is used.

#### Checklist

- [X] Chart Version bumped


