### PR TITLE
[fluentd] add fluentd

### DIFF
--- a/fluentd/.helmignore
+++ b/fluentd/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Example dirs
+examples/

--- a/fluentd/Chart.yaml
+++ b/fluentd/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: fluentd
+description: Fluentd is an open source data collector for unified logging layer.
+type: application
+version: 0.1.0
+appVersion: 1.10.3
+icon: https://github.com/fluent/fluentd-docs-gitbook/tree/8c505a3608b9b2032813b00c9b5750f4ca29ddcd/images/logo/Fluentd_square.png

--- a/fluentd/Makefile
+++ b/fluentd/Makefile
@@ -1,0 +1,75 @@
+KUBERNETES_VERSION="1.15.7"
+RELEASE = "$$(basename $$PWD)"
+
+.PHONY: install
+install:
+	helm upgrade -i --wait $(RELEASE) .
+
+.PHONY: lint
+lint: lint-daemonset lint-statefulset lint-use-udp lint-use-udp
+
+.PHONY: lint-default
+lint-default:
+	@echo "=> Linting default values.yaml"
+	helm lint --strict
+	@echo "=> Validating default value.yaml"
+	helm template . | kubeval --kubernetes-version $(KUBERNETES_VERSION)
+	@echo ""
+
+.PHONY: lint-daemonset
+lint-daemonset:
+	@echo "=> Linting examples/daemonset.yaml"
+	helm lint --strict -f examples/daemonset.yaml
+	@echo "=> Validating examples/daemonset.yaml"
+	helm template -f examples/daemonset.yaml . | kubeval --kubernetes-version $(KUBERNETES_VERSION)
+
+.PHONY: lint-statefulset
+lint-statefulset:
+	@echo "=> Linting examples/statefulset.yaml"
+	helm lint --strict -f examples/statefulset.yaml
+	@echo "=> Validating examples/statefulset.yaml"
+	helm template -f examples/statefulset.yaml . | kubeval --kubernetes-version $(KUBERNETES_VERSION)
+
+.PHONY: lint-use-udp
+lint-use-udp:
+	@echo "=> Linting examples/use-udp.yaml"
+	helm lint --strict -f examples/use-udp.yaml
+	@echo "=> Validating examples/use-udp.yaml"
+	helm template -f examples/use-udp.yaml . | kubeval --kubernetes-version $(KUBERNETES_VERSION)
+
+.PHONY: test
+test: test-daemonset test-statefulset test-use-udp test-default
+
+.PHONY: test-default
+test-default:
+	@echo "=> Testing default values.yaml"
+	helm upgrade -i --wait $(RELEASE) .
+	helm test --logs $(RELEASE)
+
+.PHONY: test-daemonset
+test-daemonset:
+	-@helm uninstall $(RELEASE)
+	@echo "=> Testing examples/daemonset.yaml"
+	helm upgrade -i --wait -f examples/daemonset.yaml $(RELEASE)-daemonset .
+	helm test --logs $(RELEASE)-daemonset
+	helm uninstall $(RELEASE)-daemonset
+
+.PHONY: test-statefulset
+test-statefulset:
+	-@helm uninstall $(RELEASE)
+	@echo "=> Testing examples/statefulset.yaml"
+	helm upgrade -i --wait -f examples/statefulset.yaml $(RELEASE)-statefulset .
+	helm test --logs $(RELEASE)-statefulset
+	helm uninstall $(RELEASE)-statefulset
+
+.PHONY: test-use-udp
+test-use-udp:
+	-@helm uninstall $(RELEASE)
+	@echo "=> Testing examples/use-udp.yaml"
+	helm upgrade -i --wait -f examples/use-udp.yaml $(RELEASE)-use-udp .
+	helm test --logs $(RELEASE)-use-udp
+	helm uninstall $(RELEASE)-use-udp
+
+.PHONY: uninstall
+uninstall:
+	helm uninstall $(RELEASE)

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -1,0 +1,145 @@
+# Fluentd
+
+[Fluentd](https://www.fluentd.org/) is an open source data collector for unified logging layer.
+
+## TL;DR;
+
+```
+$ helm install chatwork/fluentd
+```
+
+## Prerequisites
+
+* Kubernetes 1.14+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install --name my-release chatwork/fluentd
+```
+
+The command deploys the slime chart on the Kubernetes cluster in the default configuration. The [configuration](https://github.com/chatwork/charts/tree/master/fluentd#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall the `my-release` deployment:
+
+```
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the fluentd chart and their default values.
+
+|  Parameter | Description | Default |
+| --- | --- | --- |
+| `image.repository` | The image repository to pull from | `"chatwork/fluentd"` |
+| `image.tag` | The image tag to pull | `"1.10.3-1.0"` |
+| `image.pullPolicy` | Image pull policy | `"IfNotPresent"` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+| `nameOverride` | Override name of app | `""` |
+| `fullnameOverride` | Override full name of app | `""` |
+| `fluentd.http.enabled` | If true, use http input | `true` |
+| `fluentd.http.id` | Used to add the unique name of plugin configuration | `nil` |
+| `fluentd.http.label` | Route input events to <label> sections | `nil` |
+| `fluentd.http.logLevel` | Plugin-specific logging level | `nil` |
+| `fluentd.http.port` | The port to listen to | `9880` |
+| `fluentd.http.bind` | The bind address to listen to | `"0.0.0.0"` |
+| `fluentd.http.bodySizeLimit` | The size limit of the POSTed element | `"32m"` |
+| `fluentd.http.keepaliveTimeout` | The timeout limit for keeping the connection alive | `"10s"` |
+| `fluentd.http.addHttpHeaders` | Add HTTP_ prefix headers to the record | `false` |
+| `fluentd.http.addRemoteAddr` | Add REMOTE_ADDR field to the record. The value of REMOTE_ADDR is the client's address | `false` |
+| `fluentd.http.corsAllowOrigins` | White list domains for CORS | `[]` |
+| `fluentd.http.respondWithEmptyImg` | Respond with an empty gif image of 1x1 pixel (rather than an emtpy string) | `false` |
+| `fluentd.http.tls.enabled` | If true, using TLS transport | `false` |
+| `fluentd.http.tls.certPath` | Cert path to use with TLS | `""` |
+| `fluentd.http.service.enabled` | If true, use service for http input | `false` |
+| `fluentd.http.service.annotations` | Annotations to be added to service | `{}` |
+| `fluentd.http.service.labels` | Labels to be added to daemonset | `{}` |
+| `fluentd.http.service.port` | The service port for http input | `9880` |
+| `fluentd.http.service.type` | The service type for http input | `"ClusterIP"` |
+| `fluentd.forward.enabled` | If true, use forward input | `true` |
+| `fluentd.forward.id` | Used to add the unique name of plugin configuration | `nil` |
+| `fluentd.forward.label` | Route input events to <label> sections | `nil` |
+| `fluentd.forward.logLevel` | Plugin-specific logging level | `nil` |
+| `fluentd.forward.port` | The port to listen to | `24224` |
+| `fluentd.forward.bind` | The bind address to listen to | `"0.0.0.0"` |
+| `fluentd.forward.tag` | in_forward uses incoming event's tag by default(See "Protocol" section). If set tag parameter, use its value instead | `""` |
+| `fluentd.forward.addTagPrefix` | Add prefix to incoming event's tag | `nil` |
+| `fluentd.forward.lingerTimeout` | The timeout time used to set linger option | `0` |
+| `fluentd.forward.resolveHostname` | Try to resolve hostname from IP addresses or not | `false` |
+| `fluentd.forward.denyKeepalive` | Connections will be disconnected right after receiving first message if this value is true | `false` |
+| `fluentd.forward.sendKeepalivePacket` | Enable TCP keepalive of sockets. See socket article for more details | `false` |
+| `fluentd.forward.chunkSizeLimit` | The size limit of the the received chunk. If the chunk size is larger than this value, then the received chunk is dropped | `nil` |
+| `fluentd.forward.chunkSizeWarnLimit` | The warning size limit of the received chunk. If the chunk size is larger than this value, a warning message will be sent | `nil` |
+| `fluentd.forward.skipInvalidEvent` | Skip an event if incoming event is invalid | `false` |
+| `fluentd.forward.sourceAddressKey` | The field name of the client's source address. If set the value, the client's address will be set to its key | `nil` |
+| `fluentd.forward.sourceHostnameKey` | The field name of the client's hostname. If set the value, the client's hostname will be set to its key | `nil` |
+| `fluentd.forward.tls.enabled` | If true, using TLS transport | `false` |
+| `fluentd.forward.tls.certPath` | Cert path to use with TLS | `""` |
+| `fluentd.forward.service.enabled` | If true, use service for forward input | `false` |
+| `fluentd.forward.service.annotations` | Annotations to be added to service | `{}` |
+| `fluentd.forward.service.labels` | Labels to be added to service | `{}` |
+| `fluentd.forward.service.port` | The service port for forward input | `"24224"` |
+| `fluentd.forward.service.type` | The service type for forward input | `"ClusterIP"` |
+| `affinity` | Node/Pod affinities | `{}` |
+| `annotations` | Annotations to be added to daemonset or statefulset | `{}` |
+| `args` | Additional arguments | `[]` |
+| `command` | Additional command arguments | `[]` |
+| `env` | Extra environment variables that will be passed onto pods	| `[]` |
+| `extraPort` | Extra port variables that will be passed onto pods | `[]` |
+| `extraVolumeMounts` | Extra volume mounts variables that will be passed onto pods	 | `[]` |
+| `extraVolumes` | Extra volumes variables that will be passed onto pods	 | `[]` |
+| `labels` | labels to be added to daemonset or statefulset | `{}` |
+| `livenessProbe.enabled` | Enable liveness probes | `true` |
+| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | `60` |
+| `livenessProbe.periodSeconds` | How often to perform the probe | `10` |
+| `livenessProbe.timeoutSeconds` | When the probe times out | `5` |
+| `livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `6` |
+| `livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed | `1` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `podAnnotations` | Annotations to be added to pods | `{}` |
+| `podLabels` | Labels to be added to pods | `{}` |
+| `podSecurityContext` | Security context policies to add to the controller pod | `{}` |
+| `priorityClassName` | Priority Class Name | `""` |
+| `readinessProbe.enabled` | Enable readiness probes | `true` |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | `60` |
+| `readinessProbe.periodSeconds` | How often to perform the probe | `10` |
+| `readinessProbe.timeoutSeconds` | When the probe times out | `5` |
+| `readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `6` |
+| `readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed | `1` |
+| `resources` | Pod resource requests & limits | `{}` |
+| `securityContext` | Allows you to overwrite the default securityContext applied to the container | `{}` |
+| `terminationGracePeriodSeconds` | Termination grace period (in seconds) | `30` |
+| `tolerations` | Node taints to tolerate | `[]` |
+| `daemonset.enabled` | If true, enable daemonset | `true` |
+| `daemonset.useHostNetwork` | If true, use the host's network	 | `false` |
+| `daemonset.updateStrategy` | Which update strategy to deploy the daemonset | `"RollingUpdate"` |
+| `statefulset.enabled` | If true, enable statefulset | `false` |
+| `statefulset.replicas` | the number of replicas to statefulset | `1` |
+| `statefulset.updateStrategy` | Which update strategy to deploy the statefulset | `"RollingUpdate"` |
+| `extraService` | If service is required for inputs other than http/forward, use extraService | `[]` |
+| `serviceAccount.create` | If true, create a service account for the pod | `false` |
+| `serviceAccount.annotations` | Annotations for the created service account | `{}` |
+| `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `nil` |
+| `persistence.enabled` | Enable Persistence for configuration | `false` |
+| `persistence.annotations` | Annotations to be added to PVC | `{}` |
+| `persistence.existingClaim` | Name of an existing PVC | `false` |
+| `persistence.labels` | Labels to be added to PVC | `{}` |
+| `persistence.accessMode` | PVC access mode | `"ReadWriteOnce"` |
+| `persistence.size` | PVC storage request | `"8Gi"` |
+| `persistence.storageClass:` | PVC storage class  | `nil` |
+| `rbac.create` | If true, create & use RBAC resources | `false` |
+| `metrics.enabled` | If true, enable Prometheus metrics | `false` |
+| `metrics.port` | Listen port | `24231` |
+| `metrics.bind` | Binding interface | `"0.0.0.0"` |
+| `metrics.metricsPath` | Metrics HTTP endpoint | `"/metrics"` |
+| `metrics.aggregatedMetricsPath` | Metrics HTTP endpoint | `/aggregated_metrics"` |
+| `metrics.interval` | Interval to update monitor_agent information in seconds | `5` |
+| `configmaps:` | Configuration file to be mounted under /fluentd/etc/fluent.conf and /fluentd/etc/config.d/ | `{"fluent.conf": "..."}` |
+| `secrets` | Secret information file to be mounted under /secure | `{}` |

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -39,7 +39,7 @@ The following table lists the configurable parameters of the fluentd chart and t
 |  Parameter | Description | Default |
 | --- | --- | --- |
 | `image.repository` | The image repository to pull from | `"chatwork/fluentd"` |
-| `image.tag` | The image tag to pull | `"1.10.3-1.0"` |
+| `image.tag` | The image tag to pull | `"1.10.4"` |
 | `image.pullPolicy` | Image pull policy | `"IfNotPresent"` |
 | `imagePullSecrets` | Image pull secrets | `[]` |
 | `nameOverride` | Override name of app | `""` |

--- a/fluentd/examples/daemonset.yaml
+++ b/fluentd/examples/daemonset.yaml
@@ -1,0 +1,41 @@
+fluentd:
+  http:
+    enabled: true
+  forward:
+    enabled: false
+
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+
+daemonset:
+  enabled: true
+
+statefulset:
+  enabled: false
+
+serviceAccount:
+  create: true
+
+rbac:
+  create: true
+
+metrics:
+  enabled: true
+
+configmaps:
+  daemonset.conf: |-
+    <source>
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/containers.log.pos
+      tag kube.*
+      format json
+      read_from_head true
+    </source>
+    <filter kube.**>
+      @type kubernetes_metadata
+    </filter>
+    <match kube.**>
+     @type null
+    </match>

--- a/fluentd/examples/statefulset.yaml
+++ b/fluentd/examples/statefulset.yaml
@@ -1,0 +1,27 @@
+fluentd:
+  http:
+    enabled: true
+    service:
+      enabled: true
+  forward:
+    enabled: true
+    service:
+      enabled: true
+
+daemonset:
+  enabled: false
+
+statefulset:
+  enabled: true
+
+persistence:
+  enabled: true
+
+metrics:
+  enabled: true
+
+configmaps:
+  statefulset.conf: |-
+    <match **>
+     @type stdout
+    </match>

--- a/fluentd/examples/use-udp.yaml
+++ b/fluentd/examples/use-udp.yaml
@@ -1,0 +1,47 @@
+# This method is a workaround and we do not recommend it.
+# If you need to respond to the input introduced in the official announcement, please change the chart and issue a PR.
+fluentd:
+  http:
+    enabled: false
+  forward:
+    enabled: false
+
+daemonset:
+  enabled: false
+
+statefulset:
+  enabled: true
+
+extraPort:
+  - name: udp
+    containerPort: 20001
+    protocol: UDP
+
+extraService:
+ - annotations: {}
+   labels: {}
+   name: udp
+   ports:
+   - name: udp
+     port: 20001
+     protocol: UDP
+     targetPort: udp
+   type: NodePort
+
+configmaps:
+  fluent.conf: |-
+    <source>
+      @type udp
+      tag myta
+      <parse>
+        @type regexp
+        expression /^(?<field1>\d+):(?<field2>\w+)$/
+      </parse>
+      port 20001
+      bind 0.0.0.0
+      message_length_limit 1MB
+    </source>
+
+    <match **>
+     @type stdout
+    </match>

--- a/fluentd/templates/NOTES.txt
+++ b/fluentd/templates/NOTES.txt
@@ -1,0 +1,1 @@
+fluentd is now running.

--- a/fluentd/templates/_helpers.tpl
+++ b/fluentd/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluentd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluentd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "fluentd.labels" -}}
+helm.sh/chart: {{ include "fluentd.chart" . }}
+{{ include "fluentd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fluentd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluentd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC APIs.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fluentd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "fluentd.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/fluentd/templates/cluster-role.yaml
+++ b/fluentd/templates/cluster-role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+  name: {{ include "fluentd.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "fluentd.fullname" . }}
+    verbs:
+      - use
+{{- end }}

--- a/fluentd/templates/cluster-rolebinding.yaml
+++ b/fluentd/templates/cluster-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+  name: {{ include "fluentd.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "fluentd.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "fluentd.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/fluentd/templates/configmap.yaml
+++ b/fluentd/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- $root := . -}}
+{{- range $name, $tmpl := .Values.configmaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "fluentd.labels" $root | nindent 4 }}
+  name: {{ include "fluentd.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+data:
+  {{ $name }}: |
+{{ tpl $tmpl $root | indent 4 }}
+{{- end }}

--- a/fluentd/templates/daemonset.yaml
+++ b/fluentd/templates/daemonset.yaml
@@ -1,0 +1,152 @@
+{{- $root := . -}}
+{{- if and .Values.daemonset.enabled (not .Values.statefulset.enabled) }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "fluentd.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fluentd.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.daemonset.updateStrategy }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "fluentd.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      containers:
+        - command:
+            {{- toYaml .Values.command | nindent 12 }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if and .Values.livenessProbe.enabled .Values.fluentd.http.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          name: {{ .Chart.Name }}
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.metrics.port }}
+              hostPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.fluentd.http.enabled }}
+            - name: http
+              containerPort: {{ .Values.fluentd.http.port }}
+              hostPort: {{ .Values.fluentd.http.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.fluentd.forward.enabled }}
+            - name: forward
+              containerPort: {{ .Values.fluentd.forward.port }}
+              hostPort: {{ .Values.fluentd.forward.port }}
+              protocol: TCP
+            {{- end }}
+            {{- with .Values.extraPort }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if and .Values.readinessProbe.enabled .Values.fluentd.http.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            {{- range $name, $tmpl := .Values.configmaps }}
+            {{- if eq $name "fluent.conf" }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /fluentd/etc/{{ $name }}
+              subPath: {{ $name }}
+            {{- else }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /fluentd/etc/config.d/{{ $name }}
+              subPath: {{ $name }}
+            {{- end }}
+            {{- end }}
+            {{- range $name, $secret := .Values.secrets }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /secure/{{ $name }}
+              subPath: {{ $name }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.daemonset.useHostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: {{ . }}
+      {{- end }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "fluentd.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        {{- range $name, $tmpl := .Values.configmaps }}
+        - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+          configMap:
+            name: {{ include "fluentd.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+        {{- end }}
+        {{- range $name, $secrets := .Values.secrets }}
+        - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+          secret:
+            secretName: {{ include "fluentd.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/fluentd/templates/psp.yaml
+++ b/fluentd/templates/psp.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.rbac.create }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  name: {{ template "fluentd.fullname" . }}
+spec:
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'hostPath'
+{{- end }}

--- a/fluentd/templates/pvc.yaml
+++ b/fluentd/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.statefulset.enabled) }}
+{{- if .not .Values.persistence.existingClaim }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  annotations:
+    {{ toYaml .Values.persistence.annotations | nindent 4 }}
+  labels:
+    {{ include "fluentd.labels" . | nindent 4 }}
+  name: {{ template "fluentd.fullname" . }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: "{{ . }}"
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/fluentd/templates/secret.yaml
+++ b/fluentd/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- $root := . -}}
+{{- range $name, $secret := .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "fluentd.labels" $root | nindent 4 }}
+  name: {{ include "fluentd.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+type: Opaque
+data:
+  {{ $name }}: {{ tpl $secret $root | b64enc | quote }}
+{{- end }}

--- a/fluentd/templates/service-extra.yaml
+++ b/fluentd/templates/service-extra.yaml
@@ -1,0 +1,26 @@
+{{- $root := . -}}
+{{- range $i, $service := .Values.extraService }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- toYaml $service.annotations | nindent 4 }}
+  labels:
+    {{- include "fluentd.labels" $root | nindent 4 }}
+    {{- with $service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "fluentd.fullname" $root }}-{{ $service.name }}
+spec:
+  type: {{ $service.type }}
+  ports:
+    {{- range $ii, $port := $service.ports }}
+    - port: {{ $port.port }}
+      targetPort: {{ $port.targetPort }}
+      protocol: {{ $port.protocol }}
+      name: {{ $port.name }}
+    {{- end }}
+  selector:
+    {{- include "fluentd.selectorLabels" $root | nindent 4 }}
+{{- end }}

--- a/fluentd/templates/service-forward.yaml
+++ b/fluentd/templates/service-forward.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.fluentd.forward.enabled .Values.fluentd.forward.service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- toYaml .Values.fluentd.forward.service.annotations | nindent 4 }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+    {{- with .Values.fluentd.forward.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "fluentd.fullname" . }}-forward
+spec:
+  type: {{ .Values.fluentd.forward.service.type }}
+  ports:
+    - port: {{ .Values.fluentd.forward.service.port }}
+      targetPort: forward
+      protocol: TCP
+      name: forward
+  selector:
+    {{- include "fluentd.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/fluentd/templates/service-http.yaml
+++ b/fluentd/templates/service-http.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.fluentd.http.service.enabled .Values.fluentd.http.service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- toYaml .Values.fluentd.http.service.annotations | nindent 4 }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+    {{- with .Values.fluentd.http.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "fluentd.fullname" . }}-http
+spec:
+  type: {{ .Values.fluentd.http.service.type }}
+  ports:
+    - port: {{ .Values.fluentd.http.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fluentd.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/fluentd/templates/serviceaccount.yaml
+++ b/fluentd/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+  name: {{ include "fluentd.serviceAccountName" . }}
+{{- end }}

--- a/fluentd/templates/statefulset.yaml
+++ b/fluentd/templates/statefulset.yaml
@@ -1,0 +1,170 @@
+{{- $root := . -}}
+{{- if and .Values.statefulset.enabled (not .Values.daemonset.enabled) }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  labels:
+    {{- include "fluentd.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "fluentd.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fluentd.selectorLabels" . | nindent 6 }}
+  {{- if .Values.fluentd.http.enabled }}
+  serviceName: {{ include "fluentd.fullname" . }}-http
+  {{- else if .Values.fluentd.forward.enabled }}
+  serviceName: {{ include "fluentd.fullname" . }}-forward
+  {{- else }}
+  {{- $service := (index .Values.extraService 0) }}
+  serviceName: {{ include "fluentd.fullname" . }}-{{ $service.name }}
+  {{- end }}
+  replicas: {{ .Values.statefulset.replicas }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "fluentd.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      containers:
+        - args:
+            {{- toYaml .Values.args | nindent 12 }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if and .Values.livenessProbe.enabled .Values.fluentd.http.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          name: {{ .Chart.Name }}
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.fluentd.http.enabled }}
+            - name: http
+              containerPort: {{ .Values.fluentd.http.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.fluentd.forward.enabled }}
+            - name: forward
+              containerPort: {{ .Values.fluentd.forward.port }}
+              protocol: TCP
+            {{- end }}
+            {{- with .Values.extraPort }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if and .Values.readinessProbe.enabled .Values.fluentd.http.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /fluentd.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: {{ template "fluentd.fullname" . }}
+              mountPath: /var/log
+            {{- end }}
+            {{- range $name, $tmpl := .Values.configmaps }}
+            {{- if eq $name "fluent.conf" }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /fluentd/etc/{{ $name }}
+              subPath: {{ $name }}
+            {{- else }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /fluentd/etc/config.d/{{ $name }}
+              subPath: {{ $name }}
+            {{- end }}
+            {{- end }}
+            {{- range $name, $secret := .Values.secrets }}
+            - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+              mountPath: /secure/{{ $name }}
+              subPath: {{ $name }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "fluentd.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        {{- range $name, $tmpl := .Values.configmaps }}
+        - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+          configMap:
+            name: {{ include "fluentd.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+        {{- end }}
+        {{- range $name, $secrets := .Values.secrets }}
+        - name: {{ $name | replace "." "-" | replace "_" "-" | lower }}
+          secret:
+            secretName: {{ include "fluentd.fullname" $root }}-{{ $name | replace "." "-" | replace "_" "-" | lower }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  updateStrategy:
+    type: {{ .Values.statefulset.updateStrategy }}
+  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        annotations:
+          {{- toYaml .Values.persistence.annotations | nindent 10 }}
+        labels:
+          {{- include "fluentd.labels" . | nindent 10 }}
+          {{- with .Values.persistence.labels }}
+          {{- toYaml . | nindent 4 }}
+          {{- end }}
+        name: {{ template "fluentd.fullname" . }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: "{{ . }}"
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/fluentd/values.yaml
+++ b/fluentd/values.yaml
@@ -1,0 +1,357 @@
+# Default values for fluentd.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: chatwork/fluentd
+  tag: 1.10.4
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Fluentd settings
+fluentd:
+  # See: https://docs.fluentd.org/input/http
+  http:
+    enabled: true
+    id:
+    label:
+    logLevel:
+    port: 9880
+    bind: 0.0.0.0
+    bodySizeLimit: 32m
+    keepaliveTimeout: 10s
+    addHttpHeaders: false
+    addRemoteAddr: false
+    corsAllowOrigins: []
+    respondWithEmptyImg: false
+    tls:
+      enabled: false
+      certPath: ""
+    service:
+      enabled: false
+      annotations: {}
+      labels: {}
+      port: 9880
+      type: ClusterIP
+  # https://docs.fluentd.org/input/forward
+  forward:
+    enabled: true
+    id:
+    label:
+    logLevel:
+    port: 24224
+    bind: 0.0.0.0
+    addTagPrefix:
+    lingerTimeout: 0
+    resolveHostname: false
+    denyKeepalive: false
+    sendKeepalivePacket: false
+    chunkSizeLimit:
+    chunkSizeWarnLimit:
+    skipInvalidEvent: false
+    sourceAddressKey:
+    sourceHostnameKey:
+    tls:
+      enabled: false
+      path: ""
+    service:
+      enabled: false
+      annotations: {}
+      labels: {}
+      port: 24224
+      type: ClusterIP
+
+# Pod settings
+affinity: {}
+
+annotations: {}
+
+args: []
+  # - -vv
+
+command: []
+  # - -c
+  # - /fluentd/etc/fluent.conf
+
+env: []
+  # - name: FOO
+  #   value: "Hello World"
+
+# Any extra port
+extraPort: []
+  # - name: other-port
+  #   containerPort: 10008
+  #   protocol: TCP
+
+# Any extra volumeMounts
+extraVolumeMounts: []
+  # - name: volume-name
+  #   mountPath: /path/to
+
+# Any extra volumes
+extraVolumes: []
+  # - name: volime-name
+  #   hostPath:
+  #     path: /path/to
+
+labels: {}
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+nodeSelector: {}
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+priorityClassName: ""
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+terminationGracePeriodSeconds: 30
+
+tolerations: []
+
+# DaemonSet settings
+daemonset:
+  # Specifies whether or not to create a DaemonSet.
+  enabled: true
+  # Use the host networking.
+  useHostNetwork: false
+  # Update strategy for a DaemonSet.
+  updateStrategy: RollingUpdate
+
+# StatefulSet settings
+statefulset:
+  # Specifies whether or not to create a StatefulSet.
+  enabled: false
+  # Statefulset replicas
+  replicas: 1
+  # Update strategy for a StatefulSet.
+  updateStrategy: RollingUpdate
+
+# Extra Service settings
+# If service is required for inputs other than http/forward, use extraService.
+extraService: []
+  # - annotations: {}
+  #   labels: {}
+  #   name: udp
+  #   ports:
+  #   - name: udp
+  #     port: 20001
+  #     protocol: UDP
+  #     targetPort: udp
+  #   type: ClusterIP
+
+# ServiceAccount settings
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: false
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name:
+
+# Persistence settings
+persistence:
+  # Specifies whether a persistent volume claim should be created.
+  enabled: false
+  annotations: {}
+  existingClaim: false
+  labels: {}
+  accessMode: ReadWriteOnce
+  size: 8Gi
+  storageClass:
+
+# RBAC settings
+# To get the metadata of Kubernetes, set rback.create to true and use the image with fluent-plugin-kubernetes_metadata_filter installed.
+# See: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
+rbac:
+  # Specifies whether a role & rolebinding should be created.
+  create: false
+
+# Prometheus metrics endpoint settings
+# If you want to enable the metrics, please use the image with fluent-plugin-prometheus installed.
+# See: https://github.com/fluent/fluent-plugin-prometheus
+metrics:
+  # Enable HTTP endpoint to return metrics with fluentd.
+  enabled: false
+  # Binding interface.
+  port: 24231
+  # Listen port.
+  bind: 0.0.0.0
+  # Metrics HTTP endpoint.
+  metricsPath: "/metrics"
+  # Metrics HTTP endpoint.
+  aggregatedMetricsPath: "/aggregated_metrics"
+  # Lnterval to update monitor_agent information in seconds.
+  interval: 5
+
+# Fluentd configuration file
+configmaps:
+  # Define fluentd configuration files such as fluent.conf and other configuration.
+  # These are mounted under /fluentd/etc/ and /fluentd/etc/config.d/.
+  fluent.conf: |-
+    {{- if .Values.metrics.enabled -}}
+    <source>
+      @type prometheus
+      port {{ .Values.metrics.port }}
+      bind {{ .Values.metrics.bind }}
+      metrics_path {{ .Values.metrics.metricsPath }}
+      aggregated_metrics_path {{ .Values.metrics.aggregatedMetricsPath }}
+    </source>
+    <source>
+      @type prometheus_monitor
+      interval {{ .Values.metrics.interval }}
+    </source>
+    <source>
+      @type prometheus_output_monitor
+      interval {{ .Values.metrics.interval }}
+    </source>
+    <source>
+      @type prometheus_tail_monitor
+      interval {{ .Values.metrics.interval }}
+    </source>
+    {{- end }}
+
+    {{- if .Values.fluentd.http.enabled }}
+    <source>
+      @type http
+      {{- with .Values.fluentd.http.id }}
+      @id {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.label }}
+      @label {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.logLevel }}
+      @log_level {{ . }}
+      {{- end }}
+      port {{ .Values.fluentd.http.port }}
+      bind {{ .Values.fluentd.http.bind }}
+      {{- with .Values.fluentd.http.bodySizeLimit }}
+      body_size_limit {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.keepaliveTimeout }}
+      keepalive_timeout {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.addHttpHeaders }}
+      add_http_headers {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.addRemoteAddr }}
+      add_remote_addr {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.corsAllowOrigins }}
+      cors_allow_origins {{ toJson . }}
+      {{- end }}
+      {{- with .Values.fluentd.http.respondWithEmptyImg }}
+      respond_with_empty_img {{ . }}
+      {{- end }}
+      {{- if .Values.fluentd.http.tls.enabled }}
+      <transport tls>
+        cert_path {{ .Values.fluentd.http.tls.certPath }}
+      </transport>
+      {{- end }}
+    </source>
+    {{- end }}
+
+    {{- if .Values.fluentd.forward.enabled }}
+    <source>
+      @type  forward
+      {{- with .Values.fluentd.forward.id }}
+      @id {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.label }}
+      @label {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.logLevel }}
+      @log_level {{ . }}
+      {{- end }}
+      port {{ .Values.fluentd.forward.port }}
+      bind {{ .Values.fluentd.forward.bind }}
+      {{- with .Values.fluentd.forward.addTagPrefix }}
+      add_tag_prefix {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.lingerTimeout }}
+      linger_timeout {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.resolveHostname }}
+      resolve_hostname {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.denyKeepalive }}
+      deny_keepalive {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.sendKeepalivePacket }}
+      send_keepalive_packet {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.chunkSizeLimit }}
+      chunk_size_limit {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.chunkSizeWarnLimit }}
+      chunk_size_warn_limit {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.skipInvalidEvent }}
+      skip_invalid_event {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.sourceAddressKey }}
+      source_address_key {{ . }}
+      {{- end }}
+      {{- with .Values.fluentd.forward.sourceHostnameKey }}
+      source_hostname_key {{ . }}
+      {{- end }}
+      {{- if .Values.fluentd.forward.tls.enabled }}
+      <transport tls>
+        cert_path {{ .Values.fluentd.forward.tls.certPath }}
+      </transport>
+      {{- end }}
+    </source>
+    {{- end }}
+
+    {{- if gt (len .Values.configmaps) 1 }}
+    @include config.d/*.conf
+    {{- end }}
+
+# The secret to use with Fluentd
+secrets: {}
+  # Define secret information used in fluentd such as google_service_credentials.json.
+  # These are mounted under /secure.
+  # google_service_credentials.json: |
+  #   ...


### PR DESCRIPTION
Added a chart for `fluentd`.
There are other published fluentd charts, but none of them have the problem of not being able to use the official docker image and not being able to define config freely, so I created a new one.

#### Checklist

- [X] Chart Version bumped


