### PR TITLE
Modifiy aws alb chart

### DIFF
--- a/aws-alb-ingress-controller/Chart.yaml
+++ b/aws-alb-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-alb-ingress-controller
 description: A Helm chart for AWS ALB Ingress Controller
-version: 0.0.2
+version: 0.0.3
 appVersion: "v1.1.8"
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
 sources:

--- a/aws-alb-ingress-controller/Chart.yaml
+++ b/aws-alb-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-alb-ingress-controller
 description: A Helm chart for AWS ALB Ingress Controller
-version: 0.0.3
+version: 0.1.0
 appVersion: "v1.1.8"
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
 sources:

--- a/aws-alb-ingress-controller/README.md
+++ b/aws-alb-ingress-controller/README.md
@@ -89,8 +89,7 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `containerSecurityContext`| set to security context for container                                                                          | `{}`                                                                      |
 | `securityContext`         | set to security context for pod                                                                                | `{}`                                                                      |
 | `scope.ingressClass`      | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class           | `alb`                                                                     |
-| `scope.singleNamespace`   | If true, the ALB ingress controller will only act on Ingress resources in a single namespace                   | `false` (watch all namespaces)                                            |
-| `scope.watchNamespace`    | If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller)                            |
+| `scope.watchNamespace`    | the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller)                            |
 
 ```bash
 helm install chatwork/aws-alb-ingress-controller --set clusterName=MyClusterName --set autoDiscoverAwsRegion=true --set autoDiscoverAwsVpcID=true --name my-release --namespace kube-system

--- a/aws-alb-ingress-controller/templates/deployment.yaml
+++ b/aws-alb-ingress-controller/templates/deployment.yaml
@@ -38,8 +38,8 @@ spec:
         {{- with .Values.scope.ingressClass }}
         - --ingress-class={{ . }}
         {{- end }}
-        {{- with .Values.scope.singleNamespace }}
-        - --watch-namespace={{ default .Release.Namespace .Values.scope.watchNamespace }}
+        {{- with .Values.scope.watchNamespace }}
+        - --watch-namespace={{ tpl . $root }}
         {{- end }}
         {{- if not .Values.autoDiscoverAwsRegion }}
         - --aws-region={{ .Values.awsRegion }}

--- a/aws-alb-ingress-controller/values.yaml
+++ b/aws-alb-ingress-controller/values.yaml
@@ -28,14 +28,8 @@ scope:
   ## Ref: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/guide/controller/config.md#limiting-ingress-class
   ingressClass: alb
 
-  ## If true, the ALB ingress controller will only act on Ingress resources in a single namespace
-  ## Default: false; watch all namespaces
-  singleNamespace: false
-
-  ## If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace
-  ## Ref: https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/master/docs/guide/controller/config.md#limiting-namespaces
-  ## Default: namespace of the ALB ingress controller
   watchNamespace: ""
+  #watchNamespace: "{{ .Release.Namespace }}"
 
 deployment:
   annotations: {}


### PR DESCRIPTION
- It was hard to understand the options for running only in namespace, so I fixed it.
  - ref: https://github.com/chatwork/charts/blob/master/aws-secret-operator/templates/deployment.yaml#L40
- bump version to 0.1.0 bacause non-backward compatible change that would cause `scope.singleNamespace` to not working.

#### Checklist

- [x] Chart Version bumped


