### PR TITLE
[newrelic-php-agent] add priority class

### DIFF
--- a/newrelic-php-agent/Chart.yaml
+++ b/newrelic-php-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Newrelic PHP Agent
 name: newrelic-php-agent
-version: 0.4.0
+version: 0.5.0
 appVersion: "9.7.0.258"

--- a/newrelic-php-agent/README.md
+++ b/newrelic-php-agent/README.md
@@ -35,6 +35,7 @@ The following table lists the configurable parameters of the newrelic-php-agent 
 |  `daemonset.extraEnvFrom` | Extra env form | `[]` |
 |  `daemonset.extraVolumes` | Extra volumes | `[]` |
 |  `daemonset.extraVolumeMounts` | Extra volume mounts | `[]` |
+|  `daemonset.priorityClassName` | Set pod priorityClassName | `[]`|
 |  `daemonset.tolerations` | Set Pod tolerations | `[]`|
 |  `daemonset.affinity` | Set Pod affinity | `{}`|
 |  `daemonset.nodeSelector` | Set Pod nodeSelector | `{}`|
@@ -45,6 +46,7 @@ The following table lists the configurable parameters of the newrelic-php-agent 
 |  `deployment.extraEnvFrom` | Extra env form | `[]` |
 |  `deployment.extraVolumes` | Extra volumes | `[]` |
 |  `deployment.extraVolumeMounts` | Extra volume mounts | `[]` |
+|  `deployment.priorityClassName` | Set pod priorityClassName | `[]`|
 |  `deployment.tolerations` | Set Pod tolerations | `[]`|
 |  `deployment.affinity` | Set Pod affinity | `{}`|
 |  `deployment.nodeSelector` | Set Pod nodeSelector | `{}`|

--- a/newrelic-php-agent/templates/daemonset.yaml
+++ b/newrelic-php-agent/templates/daemonset.yaml
@@ -113,6 +113,9 @@ spec:
       volumes: {{ toYaml . | nindent 10 }}
 {{- end }}
 {{- end }}
+{{- with .Values.daemonset.priorityClassName }}
+      priorityClassName: {{ . }}
+{{- end }}
 {{- with .Values.daemonset.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}

--- a/newrelic-php-agent/templates/deployment.yaml
+++ b/newrelic-php-agent/templates/deployment.yaml
@@ -83,10 +83,10 @@ spec:
         volumeMounts:
           - mountPath: {{ dir $.Values.newrelic.address }}
             name: newrelic
-{{- with .Values.daemonset.extraVolumeMounts }}
+{{- with .Values.deployment.extraVolumeMounts }}
 {{ toYaml . | indent 10 }}
 {{- end }}
-{{- with .Values.daemonset.extraPorts }}
+{{- with .Values.deployment.extraPorts }}
         ports: {{ toYaml . | nindent 10 }}
 {{- end }}
 {{- else }}
@@ -106,21 +106,24 @@ spec:
         - name: newrelic
           hostPath:
             path: /var/run/newrelic
-{{- with .Values.daemonset.extraVolumes }}
+{{- with .Values.deployment.extraVolumes }}
 {{ toYaml . | indent 10 }}
 {{- end }}
 {{- else }}
-{{- with .Values.daemonset.extraVolumes }}
+{{- with .Values.deployment.extraVolumes }}
       volumes: {{ toYaml . | nindent 10 }}
 {{- end }}
 {{- end }}
-{{- with .Values.tolerations }}
+{{- with .Values.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+{{- end }}
+{{- with .Values.deployment.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
 {{- end }}
-{{- with .Values.affinity }}
+{{- with .Values.deployment.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
 {{- end }}
-{{- with .Values.daemonset.nodeSelector }}
+{{- with .Values.deployment.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/newrelic-php-agent/values.yaml
+++ b/newrelic-php-agent/values.yaml
@@ -24,6 +24,7 @@ daemonset:
   extraEnvFrom: []
   extraVolumes: []
   extraVolumeMounts: []
+  priorityClassName: ""
   tolerations: []
   affinity: {}
   nodeSelector: {}
@@ -36,6 +37,7 @@ deployment:
   extraEnvFrom: []
   extraVolumes: []
   extraVolumeMounts: []
+  priorityClassName: ""
   tolerations: []
   affinity: {}
   nodeSelector: {}


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
Priority classes are now supported.
This is to solve a problem where a `DaemonSet` wouldn't work with a large number of pods on a node.

#### Checklist

- [X] Chart Version bumped


