### PR TITLE
[php] add readinessGates

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.19.0
+version: 0.20.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `podLabels` | Label specified for pod in deployment | `{}` |
 |  `podAnnotations` | Annotation specified for pod in deployment | `{}` |
 |  `imagePullSecrets` | Name of Secret resource containing private registry credentials | `[]` |
+|  `readinessGates` | Pod readiness extensions | `{}` |
 |  `restartPolicy` | Container restart policy | `""` |
 |  `terminationGracePeriodSeconds` | Termination grace period (in seconds) | `nil` |
 |  `securityContext` | Enable security context | `{}` |

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -246,6 +246,12 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- tpl (toYaml .) $root | nindent 8 }}
         {{- end }}
+      {{- with .Values.readinessGates }}
+      readinessGates:
+        {{- range $k, $v := . }}
+        - conditionType: '{{ tpl $v.conditionType $root }}'
+        {{- end }}
+      {{- end }}
       {{- with .Values.restartPolicy }}
       restartPolicy: {{ . }}
       {{- end }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -19,6 +19,8 @@ podAnnotations: {}
 
 imagePullSecrets: []
 
+readinessGates: {}
+
 restartPolicy: ""
 
 securityContext: {}


### PR DESCRIPTION
https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/pod-conditions/
Added support for `readinessGates` for rolling updates with no downtime when using alb Ingress.

#### Checklist

- [X] Chart Version bumped


