### PR TITLE
[php] change to disable NGINX to use a different pod or NGINX Ingress

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.20.0
+version: 0.21.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -110,6 +110,7 @@ We recommend that you embed the source code in your container and copy it to the
 
 |  Parameter | Description | Default |
 | --- | --- | --- |
+|  `nginx.enabled` | Enable NGINX container | `true` |
 |  `nginx.image.repository` | The image repository to pull from | `nginx` |
 |  `nginx.image.tag` | The image tag to pull | `1.17-alpine` |
 |  `nginx.image.pullPolicy` | Image pull policy | `IfNotPresent` |
@@ -136,6 +137,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `fpm.image.tag` | The image tag to pull | `7.4-fpm-alpine` |
 |  `fpm.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 |  `fpm.command` | Command to execute | `[]` |
+|  `fpm.containerPort` | Listen port of NGINX container | `nil` |
 |  `fpm.lifecycle` | PHP-FPM container lifecycle hooks | `{}` |
 |  `fpm.livenessProbe` | Liveness probe settings | `{}` |
 |  `fpm.readinessProbe` | Readiness probe settings | `{}` |

--- a/php/templates/configmap-busybox.yaml
+++ b/php/templates/configmap-busybox.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.busybox.enabled }}
 {{- range $name, $tmpl := .Values.busybox.templates }}
 ---
 apiVersion: v1
@@ -21,4 +22,5 @@ data:
   {{ $k }}: {{ tpl $v $root | toYaml | indent 2 }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/php/templates/configmap-nginx.yaml
+++ b/php/templates/configmap-nginx.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.nginx.enabled }}
 {{- range $name, $tmpl := .Values.nginx.templates }}
 ---
 apiVersion: v1
@@ -21,4 +22,5 @@ data:
   {{ $k }}: {{ tpl $v $root | toYaml | indent 2 }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -28,18 +28,22 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- if .Values.busybox.enabled }}
         checksum/configmap-busybox: {{ include (print $.Template.BasePath "/configmap-busybox.yaml") . | sha256sum }}
-        checksum/configmap-fpm: {{ include (print $.Template.BasePath "/configmap-fpm.yaml") . | sha256sum }}
-        checksum/configmap-nginx: {{ include (print $.Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
         checksum/secret-busybox: {{ include (print $.Template.BasePath "/secret-busybox.yaml") . | sha256sum }}
-        checksum/secret-fpm: {{ include (print $.Template.BasePath "/secret-fpm.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.nginx.enabled }}
+        checksum/configmap-nginx: {{ include (print $.Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
         checksum/secret-nginx: {{ include (print $.Template.BasePath "/secret-nginx.yaml") . | sha256sum }}
+        {{- end }}
+        checksum/configmap-fpm: {{ include (print $.Template.BasePath "/configmap-fpm.yaml") . | sha256sum }}
+        checksum/secret-fpm: {{ include (print $.Template.BasePath "/secret-fpm.yaml") . | sha256sum }}
         {{- range $k, $v := .Values.podAnnotations }}
         {{ $k }}: {{ tpl $v $root | toYaml | indent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.busybox.enabled }}
       initContainers:
+        {{- if .Values.busybox.enabled }}
         - name: "{{ template "php.fullname" . }}-busybox"
           image: "{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
@@ -59,8 +63,9 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- tpl (toYaml .) $root | nindent 12 }}
             {{- end }}
-      {{- end }}
+        {{- end }}
       containers:
+        {{- if .Values.nginx.enabled }}
         - name: "{{ template "php.fullname" . }}-nginx"
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
@@ -91,8 +96,10 @@ spec:
           lifecycle: {{ tpl (toYaml .) $root | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if not .Values.fpm.containerPort }}
             - name: php-fpm-sock
               mountPath: /var/run/php-fpm
+            {{- end }}
             {{- if .Values.busybox.enabled }}
             - name: share
               mountPath: {{ .Values.sharedPath }}
@@ -113,14 +120,21 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- tpl (toYaml .) $root | nindent 12 }}
             {{- end }}
+        {{- end }}
         - name: "{{ template "php.fullname" . }}-fpm"
           image: "{{ .Values.fpm.image.repository }}:{{ .Values.fpm.image.tag }}"
           imagePullPolicy: {{ .Values.fpm.image.pullPolicy }}
           {{- with .Values.fpm.command }}
           command: {{ tpl (toYaml .) $root | nindent 12 }}
           {{- end }}
-          {{- with .Values.fpm.extraPorts }}
-          ports: {{ tpl (toYaml .) $root | nindent 12 }}
+          {{- if .Values.fpm.containerPort }}
+          ports:
+            - name: fcgi
+              containerPort: {{ .Values.fpm.containerPort }}
+              protocol: TCP
+            {{- with .Values.fpm.extraPorts }}
+            {{ tpl (toYaml .) $root | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.fpm.extraEnv }}
           env: {{ tpl (toYaml .) $root | nindent 12 }}
@@ -143,8 +157,10 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if not .Values.fpm.containerPort }}
             - name: php-fpm-sock
               mountPath: /var/run/php-fpm
+            {{- end }}
             {{- if index .Values.fpm.templates "php.ini" }}
             - name: php-ini
               mountPath: /usr/local/etc/php/php.ini
@@ -188,12 +204,15 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if not .Values.fpm.containerPort }}
         - name: php-fpm-sock
           emptyDir: {}
+        {{- end }}
         {{- if .Values.busybox.enabled }}
         - name: share
           emptyDir: {}
         {{- end }}
+        {{- if .Values.nginx.enabled }}
         {{- if index .Values.nginx.templates "nginx.conf" }}
         - name: nginx-conf
           configMap:
@@ -203,6 +222,7 @@ spec:
         - name: default-conf
           configMap:
             name: '{{ template "php.fullname" . }}-nginx-default-conf'
+        {{- end }}
         {{- end }}
         {{- if index .Values.fpm.templates "php.ini" }}
         - name: php-ini

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -18,7 +18,11 @@ metadata:
 spec:
   backend:
     serviceName: {{ template "php.fullname" . }}
+    {{- if .Values.nginx.enabled }}
     servicePort: {{ .Values.service.port | default .Values.nginx.containerPort }}
+    {{- else }}
+    servicePort: {{ .Values.service.port | default .Values.fpm.containerPort }}
+    {{- end }}
   {{- with .Values.ingress.tls }}
   tls: {{ tpl (toYaml .) $root | nindent 4 }}
   {{- end }}
@@ -33,6 +37,10 @@ spec:
           - path: /*
             backend:
               serviceName: {{ template "php.fullname" $root }}
+              {{- if $root.Values.nginx.enabled }}
               servicePort: {{ $root.Values.service.port | default $root.Values.nginx.containerPort }}
+              {{- else }}
+              servicePort: {{ $root.Values.service.port | default $root.Values.fpm.containerPort }}
+              {{- end }}
     {{- end }}
 {{- end }}

--- a/php/templates/secret-busybox.yaml
+++ b/php/templates/secret-busybox.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.busybox.enabled }}
 {{- range $name, $secret := .Values.busybox.secrets }}
 ---
 apiVersion: v1
@@ -21,4 +22,5 @@ data:
   {{ $k }}: {{ tpl $v $root | b64enc | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/php/templates/secret-nginx.yaml
+++ b/php/templates/secret-nginx.yaml
@@ -1,4 +1,5 @@
 {{- $root := . -}}
+{{- if .Values.nginx.enabled }}
 {{- range $name, $secret := .Values.nginx.secrets }}
 ---
 apiVersion: v1
@@ -21,4 +22,5 @@ data:
   {{ $k }}: {{ tpl $v $root | b64enc | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/php/templates/service.yaml
+++ b/php/templates/service.yaml
@@ -18,19 +18,14 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - name: default
+      {{- if .Values.nginx.enabled }}
       port: {{ .Values.service.port | default .Values.nginx.containerPort }}
+      {{- else }}
+      port: {{ .Values.service.port | default .Values.fpm.containerPort }}
+      {{- end }}
       protocol: TCP
       targetPort: default
     {{- with .Values.service.extraPorts }}
     {{- tpl (toYaml .) $root | nindent 4 }}
-    {{- else }}
-    {{- range .Values.nginx.extraPortss }}
-    - name: {{ tpl .name $root }}
-      port: {{ tpl .containerPort $root }}
-      {{- with .protocol }}
-      protocol: {{ tpl . $root }}
-      {{- end }}
-      targetPort: {{ tpl .name $root | default .containerPort }}
-    {{- end }}
     {{- end }}
   selector: {{ include "php.selectorLabels" . | nindent 4 }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -163,6 +163,7 @@ busybox:
 
 # NGINX
 nginx:
+  enabled: true
   image:
     repository: nginx
     tag: 1.17-alpine
@@ -317,6 +318,9 @@ fpm:
   # - php-fpm
   # - -d zend_extension=xdebug.so
 
+  # If containerPort is null, then PHP-FPM works with sock.
+  containerPort: null
+
   lifecycle: {}
     #postStart:
     #  exec:
@@ -386,7 +390,11 @@ fpm:
   templates:
     zz-kubernetes.conf: |
       [www]
+      {{- if .Values.fpm.containerPort }}
+      listen = 127.0.0.1:{{ .Values.fpm.containerPort }}
+      {{- else }}
       listen = /var/run/php-fpm/php-fpm.sock
+      {{- end }}
       listen.owner = nobody
       listen.group = nogroup
       listen.mode = 0660


### PR DESCRIPTION
Change to disable NGINX to use a different pod or NGINX Ingress.

Changes

- NGINX can now be disabled
- Added support for port mode in PHP-FPM

#### Checklist

- [X] Chart Version bumped


