### PR TITLE
[php] support for the option not to mount the default template

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.21.0
+version: 0.22.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -126,6 +126,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `nginx.extraVolumes` | Additional volumes | `[]` |
 |  `nginx.extraVolumeMounts` | Additional volumeMounts | `[]` |
 |  `nginx.secrets` | Additional Secret as a string to be passed to the tpl function | `{}` |
+|  `nginx.disabledDefaultTemplatesMount` | If true, do not mount the default templates to the pod | `false` |
 |  `nginx.templates` | Additional ConfigMap as a string to be passed to the tpl function. | setting `nginx.conf`, `conf.d/default.conf` |
 |  `nginx.annotations` | Grant annotations to ConfigMap of `nginx.templates`, Secrets of `nginx.secrets` | `{}` |
 
@@ -148,6 +149,7 @@ We recommend that you embed the source code in your container and copy it to the
 |  `fpm.extraVolumes` | Additional volumes | `[]` |
 |  `fpm.extraVolumeMounts` | Additional volumeMounts | `[]` |
 |  `fpm.secrets` | Additional Secret as a string to be passed to the tpl function | `{}` |
+|  `fpm.disabledDefaultTemplatesMount` | If true, do not mount the default templates to the pod | `false` |
 |  `fpm.templates` | Additional ConfigMap as a string to be passed to the tpl function. | setting `php-fpm.conf`,`www.conf` |
 |  `fpm.annotations` | Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets` | `{}` |
 

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -104,6 +104,7 @@ spec:
             - name: share
               mountPath: {{ .Values.sharedPath }}
             {{- end }}
+            {{- if not .Values.nginx.disabledDefaultTemplatesMount }}
             {{- if index .Values.nginx.templates "nginx.conf" }}
             - name: nginx-conf
               mountPath: /etc/nginx/nginx.conf
@@ -113,6 +114,7 @@ spec:
             - name: default-conf
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: default.conf
+            {{- end }}
             {{- end }}
             {{- with .Values.nginx.extraVolumeMounts }}
             {{- tpl (toYaml .) $root | nindent 12 }}
@@ -161,6 +163,7 @@ spec:
             - name: php-fpm-sock
               mountPath: /var/run/php-fpm
             {{- end }}
+            {{- if not .Values.fpm.disabledDefaultTemplatesMount }}
             {{- if index .Values.fpm.templates "php.ini" }}
             - name: php-ini
               mountPath: /usr/local/etc/php/php.ini
@@ -191,6 +194,7 @@ spec:
               mountPath: /usr/local/etc/php-fpm.d/zz-kubernetes.conf
               subPath: zz-kubernetes.conf
             {{- end }}
+            {{- end }}
             {{- if .Values.busybox.enabled }}
             - name: share
               mountPath: {{ .Values.sharedPath }}
@@ -212,7 +216,7 @@ spec:
         - name: share
           emptyDir: {}
         {{- end }}
-        {{- if .Values.nginx.enabled }}
+        {{- if and .Values.nginx.enabled (not .Values.nginx.disabledDefaultTemplatesMount) }}
         {{- if index .Values.nginx.templates "nginx.conf" }}
         - name: nginx-conf
           configMap:
@@ -224,6 +228,7 @@ spec:
             name: '{{ template "php.fullname" . }}-nginx-default-conf'
         {{- end }}
         {{- end }}
+        {{- if not .Values.fpm.disabledDefaultTemplatesMount }}
         {{- if index .Values.fpm.templates "php.ini" }}
         - name: php-ini
           configMap:
@@ -253,6 +258,7 @@ spec:
         - name: zz-kubernetes-conf
           configMap:
             name: '{{ template "php.fullname" . }}-fpm-zz-kubernetes-conf'
+        {{- end }}
         {{- end }}
         {{- with .Values.busybox.extraVolumes }}
         {{- tpl (toYaml .) $root | nindent 8 }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -255,6 +255,10 @@ nginx:
   #    BAR: 2
   #    BAZ: 3
 
+  # If true, do not mount the templates to the pod.
+  # This is for use in environment variables only, or to include when building containers.
+  disabledDefaultTemplatesMount: false
+
   # configuration NGINX templates.
   # If you can not be satisfied with the default settings you can change the template.
   templates:
@@ -384,6 +388,10 @@ fpm:
   #    FOO: 1
   #    BAR: 2
   #    BAZ: 3
+
+  # If true, do not mount the templates to the pod.
+  # This is for use in environment variables only, or to include when building containers.
+  disabledDefaultTemplatesMount: false
 
   # configuration PHP-FPM templates
   # If you can not be satisfied with the default settings you can change the template.


### PR DESCRIPTION
Support for the option not to mount the default template.
It makes it easier to use use cases that prioritize configuration files included in containers.

#### Checklist

- [X] Chart Version bumped


