### PR TITLE
[php] fixes to allow you to change the details on the PSP

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.22.0
+version: 0.23.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -77,6 +77,15 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `autoscaling.maxReplicas` | Max pods for HorizontalPodAutoscaler | `nil` |
 |  `autoscaling.metrics` | Metrics used for autoscaling | `nil` |
 |  `rbac.create` | If true, create & use RBAC resources | `true` |
+|  `psp.create` |  | `false` |
+|  `psp.annotations` | Annotations for the created PSP  | `{}` |
+|  `psp.labels` | Labels for the created PSP | `{}` |
+|  `psp.name` | The name of the PSP to use. If not set and create is true, a name is generated using the fullname template | `nil` |
+|  `psp.seLinux` | The SELinux context of the container | `{"rule":"RunAsAny"}` |
+|  `psp.supplementalGroups` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
+|  `psp.runAsUser` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
+|  `psp.fsGroup` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
+|  `psp.volumes` | Usage of volume types | `['*']` |
 |  `serviceAccount.create` | If true, create a service account for the pod | `true` |
 |  `serviceAccount.annotations` | Annotations for the created service account | `{}` |
 |  `serviceAccount.labels` | Labels for the created service account | `{}` |

--- a/php/templates/_helpers.tpl
+++ b/php/templates/_helpers.tpl
@@ -61,3 +61,10 @@ Create the name of the service account to use
 {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the PSP to use
+*/}}
+{{- define "php.pspName" -}}
+{{ .Values.psp.name | default (include "php.fullname" .) }}
+{{- end -}}

--- a/php/templates/psp.yaml
+++ b/php/templates/psp.yaml
@@ -1,22 +1,29 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.psp.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
     {{- include "php.labels" . | nindent 4 }}
-  name: {{ template "php.fullname" . }}
+    {{- with .Values.psp.labels }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+  annotations:
+    {{- with .Values.psp.annotations }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
+  name: {{ template "php.pspName" . }}
 spec:
   privileged: false
   seLinux:
-    rule: RunAsAny
+    {{- toYaml .Values.psp.seLinux | nindent 4 }}
   supplementalGroups:
-    rule: RunAsAny
+    {{- toYaml .Values.psp.supplementalGroups | nindent 4 }}
   runAsUser:
-    rule: RunAsAny
+    {{- toYaml .Values.psp.runAsUser | nindent 4 }}
   fsGroup:
-    rule: RunAsAny
+    {{- toYaml .Values.psp.fsGroup | nindent 4 }}
   volumes:
-    - '*'
+    {{- toYaml .Values.psp.volumes | nindent 4 }}
   allowedUnsafeSysctls:
     {{- range .Values.securityContext.sysctls }}
     - '{{ .name }}'

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -72,6 +72,23 @@ rbac:
   # Specifies whether a role and rolebinding should be created.
   create: true
 
+# PSP
+psp:
+  create: false
+  annotations: {}
+  labels: {}
+  name:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - '*'
+
 # SA
 serviceAccount:
   # Specifies whether a service account should be created.


### PR DESCRIPTION
Fixes to allow you to change the details on the PSP.

Changes:
- Change to create RBAC and not create PSP
- Fixed to allow you to change the name and various items

**NOTE: PSP was created with `rbac.create:true`, but it has been braked changed so that PSP is not created unless it is `psp.create:true`.**

#### Checklist

- [X] Chart Version bumped


