### PR TITLE
[php] v1.0.0

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: php
-version: 0.23.0
+version: 1.0.0
 description: PHP-FPM Web Application
 icon: http://php.net/images/logos/php-logo-bigger.png

--- a/php/README.md
+++ b/php/README.md
@@ -70,8 +70,8 @@ The following table lists the configurable parameters of the PHP chart and their
 | `podDisruptionBudget.enabled` | If true, create a pod disruption budget for keeper pods | `false` |
 | `podDisruptionBudget.annotations` | Annotations for the pod disruption budget | `{}` |
 | `podDisruptionBudget.labels` | Labels for the pod disruption budget | `{}` |
-| `podDisruptionBudget.minAvailabled` | Minimum number / percentage of pods that should remain scheduled | `nil` |
-| `podDisruptionBudget.maxAvailabled` | Minimum number / percentage of pods that should remain scheduled | `nil` |
+| `podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `nil` |
+| `podDisruptionBudget.maxUnavailable` | Minimum number / percentage of pods that should remain scheduled | `nil` |
 | `autoscaling.enabled` | If true, create a horizonal pod autoscaler | `false` |
 | `autoscaling.annotations` | Annotations for the horizonal pod autoscaler | `{}` |
 | `autoscaling.labels` | Annotations for the horizonal pod autoscaler | `{}` |

--- a/php/README.md
+++ b/php/README.md
@@ -54,8 +54,6 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `terminationGracePeriodSeconds` | Termination grace period (in seconds) | `nil` |
 |  `securityContext` | Enable security context | `{}` |
 |  `serviceAccountName` | Existing ServiceAccount to use | `""` |
-|  `extraVolumes` | Additional volumes to all container | `[]` |
-|  `extraVolumeMounts` | Additional volumeMounts to all container | `[]` |
 |  `tolerations` | Pod taint tolerations for deployment | `[]` |
 |  `affinity` | Node / Pod affinities | `{}` |
 |  `service.type` | Changes to ClusterIP automatically if ingress enabled | `LoadBalancer` |

--- a/php/README.md
+++ b/php/README.md
@@ -42,53 +42,57 @@ The following table lists the configurable parameters of the PHP chart and their
 
 |  Parameter | Description | Default |
 | --- | --- | --- |
-|  `sharedPath` | Path shared by busybox/nginx/fpm | `/var/www/html` |
-|  `replicaCount` | Number of pods to start with deployment | `1` |
-|  `strategy` | Update strategy of pod in deployment | `type`: `RollingUpdate` |
-|  `labels` | Label specified for deployment | `{}` |
-|  `podLabels` | Label specified for pod in deployment | `{}` |
-|  `podAnnotations` | Annotation specified for pod in deployment | `{}` |
-|  `imagePullSecrets` | Name of Secret resource containing private registry credentials | `[]` |
-|  `readinessGates` | Pod readiness extensions | `{}` |
-|  `restartPolicy` | Container restart policy | `""` |
-|  `terminationGracePeriodSeconds` | Termination grace period (in seconds) | `nil` |
-|  `securityContext` | Enable security context | `{}` |
-|  `serviceAccountName` | Existing ServiceAccount to use | `""` |
-|  `tolerations` | Pod taint tolerations for deployment | `[]` |
-|  `affinity` | Node / Pod affinities | `{}` |
-|  `service.type` | Changes to ClusterIP automatically if ingress enabled | `LoadBalancer` |
-|  `service.port` | Port to advertise the main web service in LoadBalancer mode | `nil` |
-|  `service.extraPorts` | Additional ports | `[]` |
-|  `service.labels` | Label specified for service | `{}` |
-|  `service.annotations` | Annotation specified for service | `{}` |
-|  `ingress.enabled` | Enables Ingress | `false` |
-|  `ingress.labels` | Label specified for ingress | `{}` |
-|  `ingress.annotations` | Annotation specified for ingress | `{}` |
-|  `ingress.hosts` | Ingress accepted hostname | `[]` |
-|  `ingress.preferPaths` | Paths that takes precedence over the ingress.path | `nil` |
-|  `ingress.tls` | TLS Secret (certificates)  | `false` |
-|  `podDisruptionBudget.enabled` | If true, create a pod disruption budget for keeper pods | `false` |
-|  `podDisruptionBudget.minAvailabled` | Minimum number / percentage of pods that should remain scheduled | `nil` |
-|  `podDisruptionBudget.maxAvailabled` | Minimum number / percentage of pods that should remain scheduled | `nil` |
-|  `autoscaling.enabled` | If true, create a pod disruption budget for keeper pods | `false` |
-|  `autoscaling.minReplicas` | Min pods for HorizontalPodAutoscaler | `nil` |
-|  `autoscaling.maxReplicas` | Max pods for HorizontalPodAutoscaler | `nil` |
-|  `autoscaling.metrics` | Metrics used for autoscaling | `nil` |
-|  `rbac.create` | If true, create & use RBAC resources | `true` |
-|  `psp.create` |  | `false` |
-|  `psp.annotations` | Annotations for the created PSP  | `{}` |
-|  `psp.labels` | Labels for the created PSP | `{}` |
-|  `psp.name` | The name of the PSP to use. If not set and create is true, a name is generated using the fullname template | `nil` |
-|  `psp.seLinux` | The SELinux context of the container | `{"rule":"RunAsAny"}` |
-|  `psp.supplementalGroups` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
-|  `psp.runAsUser` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
-|  `psp.fsGroup` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
-|  `psp.volumes` | Usage of volume types | `['*']` |
-|  `serviceAccount.create` | If true, create a service account for the pod | `true` |
-|  `serviceAccount.annotations` | Annotations for the created service account | `{}` |
-|  `serviceAccount.labels` | Labels for the created service account | `{}` |
-|  `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `` |
-|  `test.enabled` | Enables helm test | `true` |
+| `sharedPath` | Path shared by busybox/nginx/fpm | `/var/www/html` |
+| `replicaCount` | Number of pods to start with deployment | `1` |
+| `strategy` | Update strategy of pod in deployment | `{"type":"RollingUpdate"}` |
+| `annotations` | Annotation specified for deployment  | `{}` |
+| `labels` | Label specified for deployment | `{}` |
+| `podLabels` | Label specified for pod in deployment | `{}` |
+| `podAnnotations` | Annotation specified for pod in deployment | `{}` |
+| `imagePullSecrets` | Name of Secret resource containing private registry credentials | `[]` |
+| `readinessGates` | Pod readiness extensions | `{}` |
+| `restartPolicy` | Container restart policy | `"Always"` |
+| `securityContext` | Enable security context | `{}` |
+| `serviceAccountName` | Existing ServiceAccount to use | `""` |
+| `terminationGracePeriodSeconds` | Termination grace period (in seconds) | `70` |
+| `tolerations` | Pod taint tolerations for deployment | `[]` |
+| `affinity` | Node / Pod affinities | `{}` |
+| `service.annotations` | Annotation specified for service | `{}` |
+| `service.labels` | Label specified for service | `{}` |
+| `service.type` | Changes to ClusterIP automatically if ingress enabled | `LoadBalancer` |
+| `service.port` | Port to advertise the main web service in LoadBalancer mode | `nil` |
+| `service.extraPorts` | Additional ports | `[]` |
+| `ingress.enabled` | Enables Ingress | `false` |
+| `ingress.annotations` | Annotation specified for ingress | `{}` |
+| `ingress.labels` | Label specified for ingress | `{}` |
+| `ingress.hosts` | Ingress accepted hostname | `[]` |
+| `ingress.tls` | TLS Secret (certificates)  | `[]` |
+| `podDisruptionBudget.enabled` | If true, create a pod disruption budget for keeper pods | `false` |
+| `podDisruptionBudget.annotations` | Annotations for the pod disruption budget | `{}` |
+| `podDisruptionBudget.labels` | Labels for the pod disruption budget | `{}` |
+| `podDisruptionBudget.minAvailabled` | Minimum number / percentage of pods that should remain scheduled | `nil` |
+| `podDisruptionBudget.maxAvailabled` | Minimum number / percentage of pods that should remain scheduled | `nil` |
+| `autoscaling.enabled` | If true, create a horizonal pod autoscaler | `false` |
+| `autoscaling.annotations` | Annotations for the horizonal pod autoscaler | `{}` |
+| `autoscaling.labels` | Annotations for the horizonal pod autoscaler | `{}` |
+| `autoscaling.minReplicas` | Min pods for horizontal pod autoscaler | `nil` |
+| `autoscaling.maxReplicas` | Max pods for Horizontal pod autoscaler | `nil` |
+| `autoscaling.metrics` | Metrics used for autoscaling | `{}` |
+| `rbac.create` | If true, create & use RBAC resources | `true` |
+| `podSecurityPolicy.create` |  | `false` |
+| `podSecurityPolicy.annotations` | Annotations for the created PSP  | `{}` |
+| `podSecurityPolicy.labels` | Labels for the created PSP | `{}` |
+| `podSecurityPolicy.name` | The name of the PSP to use. If not set and create is true, a name is generated using the fullname template | `nil` |
+| `podSecurityPolicy.seLinux` | The SELinux context of the container | `{"rule":"RunAsAny"}` |
+| `podSecurityPolicy.supplementalGroups` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
+| `podSecurityPolicy.runAsUser` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
+| `podSecurityPolicy.fsGroup` | The user and group IDs of the container | `{"rule":"RunAsAny"}` |
+| `podSecurityPolicy.volumes` | Usage of volume types | `['*']` |
+| `serviceAccount.create` | If true, create a service account for the pod | `true` |
+| `serviceAccount.annotations` | Annotations for the created service account | `{}` |
+| `serviceAccount.labels` | Labels for the created service account | `{}` |
+| `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `test.enabled` | Enables helm test | `true` |
 
 ### Init containers
 
@@ -98,19 +102,19 @@ We recommend that you embed the source code in your container and copy it to the
 
 |  Parameter | Description | Default |
 | --- | --- | --- |
-|  `busybox.enabled` | Enables initial containers and share volume with busybox | `true` |
-|  `busybox.image.repository` | The image repository to pull from | `busybox` |
-|  `busybox.image.tag` | The image tag to pull | `latest` |
-|  `busybox,image.pullPolicy` | Image pull policy | `IfNotPresent` |
-|  `busybox.command` | Initialize command | `["sh", "-c", "echo '<?php phpinfo();' > /var/www/html/index.php"]` |
-|  `busybox.sharedPath` | Path of directory to mount | `sharePath` |
-|  `busybox.extraEnv` | Additional environment variables | `[]` |
-|  `busybox.extraEnvFrom` | Additional envFrom | `[]` |
-|  `busybox.extraVolumes` | Additional volumes | `[]` |
-|  `busybox.extraVolumeMounts` | Additional volumeMounts | `[]` |
-|  `busybox.secrets` | Additional Secret as a string to be passed to the tpl function | `{}` |
-|  `busybox.templates` | Additional ConfigMap as a string to be passed to the tpl function. | `{}` |
-|  `busybox.annotations` | Grant annotations to ConfigMap of `busybox.templates`, Secrets of `busybox.secrets` | `{}` |
+| `busybox.enabled` | Enables initial containers and share volume with busybox | `true` |
+| `busybox.image.repository` | The image repository to pull from | `busybox` |
+| `busybox.image.tag` | The image tag to pull | `latest` |
+| `busybox,image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `busybox.command` | Initialize command | `["sh", "-c", "echo '<?php echo \"Hello World\";' > /var/www/html/index.php"]` |
+| `busybox.sharedPath` | Path of directory to mount | `nil` |
+| `busybox.extraEnv` | Additional environment variables | `[]` |
+| `busybox.extraEnvFrom` | Additional envFrom | `[]` |
+| `busybox.extraVolumes` | Additional volumes | `[]` |
+| `busybox.extraVolumeMounts` | Additional volumeMounts | `[]` |
+| `busybox.secrets` | Additional Secret as a string to be passed to the tpl function | `{}` |
+| `busybox.enableAutoMountConfigMap` | If true, ConfigMap will be volume-mounted to the pod automatically | `true` |
+| `busybox.configMaps` | Additional ConfigMap as a string to be passed to the tpl function. | `{}` |
 
 ## Nginx containers
 
@@ -123,8 +127,8 @@ We recommend that you embed the source code in your container and copy it to the
 |  `nginx.command` | Command to execute | `[]` |
 |  `nginx.containerPort` | Listen port of NGINX container | `80` |
 |  `nginx.lifecycle` | NGINX container lifecycle hooks | `{}` |
-|  `nginx.livenessProbe` | Liveness probe settings | `{ "httpGet": { "path": "/status", "port": 7777 } "initialDelaySeconds": 15, "periodSeconds": 5, "timeoutSeconds": 1, "successThreshold": 1, "failureThreshold": 3 }` |
-|  `nginx.readinessProbe` | Readiness probe settings | `{ "httpGet": { "path": "/ping", "port": 7777 } "initialDelaySeconds": 15, "periodSeconds": 5, "timeoutSeconds": 1, "successThreshold": 1, "failureThreshold": 3 }` |
+|  `nginx.livenessProbe` | Liveness probe settings | `{ "httpGet": { "path": "/", "port": 80 } "initialDelaySeconds": 15, "periodSeconds": 5, "timeoutSeconds": 1, "successThreshold": 1, "failureThreshold": 3 }` |
+|  `nginx.readinessProbe` | Readiness probe settings | `{ "httpGet": { "path": "/", "port": 80 } "initialDelaySeconds": 15, "periodSeconds": 5, "timeoutSeconds": 1, "successThreshold": 1, "failureThreshold": 3 }` |
 |  `nginx.resources` | NGINX resources requests & limits | `[]` |
 |  `nginx.extraEnv` | Additional environment variables | `{}` |
 |  `nginx.extraEnvFrom` | Additional envFrom | `[]` |
@@ -132,9 +136,8 @@ We recommend that you embed the source code in your container and copy it to the
 |  `nginx.extraVolumes` | Additional volumes | `[]` |
 |  `nginx.extraVolumeMounts` | Additional volumeMounts | `[]` |
 |  `nginx.secrets` | Additional Secret as a string to be passed to the tpl function | `{}` |
-|  `nginx.disabledDefaultTemplatesMount` | If true, do not mount the default templates to the pod | `false` |
-|  `nginx.templates` | Additional ConfigMap as a string to be passed to the tpl function. | setting `nginx.conf`, `conf.d/default.conf` |
-|  `nginx.annotations` | Grant annotations to ConfigMap of `nginx.templates`, Secrets of `nginx.secrets` | `{}` |
+|  `nginx.enableAutoMountConfigMap` | If true, ConfigMap will be volume-mounted to the pod automatically | `true` |
+|  `nginx.configMaps` | Additional ConfigMap as a string to be passed to the tpl function. | setting `nginx.conf`, `conf.d/default.conf` |
 
 ## PHP-FPM containers
 
@@ -155,9 +158,8 @@ We recommend that you embed the source code in your container and copy it to the
 |  `fpm.extraVolumes` | Additional volumes | `[]` |
 |  `fpm.extraVolumeMounts` | Additional volumeMounts | `[]` |
 |  `fpm.secrets` | Additional Secret as a string to be passed to the tpl function | `{}` |
-|  `fpm.disabledDefaultTemplatesMount` | If true, do not mount the default templates to the pod | `false` |
-|  `fpm.templates` | Additional ConfigMap as a string to be passed to the tpl function. | setting `php-fpm.conf`,`www.conf` |
-|  `fpm.annotations` | Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets` | `{}` |
+|  `fpm.enableAutoMountConfigMap` | If true, ConfigMap will be volume-mounted to the pod automatically | `true` |
+|  `fpm.configMaps` | Additional ConfigMap as a string to be passed to the tpl function. | setting `php-fpm.conf`,`www.conf` |
 
 ### Manage request timeout and graceful shutdown
 
@@ -190,7 +192,7 @@ fpm:
       process_control_timeout = {{ your_fpm_process_control_timeout }}
 
   lifecycle:
-    preStop: ["/bin/sh", "-c", "sleep 5; kill -QUIT 1; sleep {{ $fpm_request_timeout }} "]
+    preStop: ["/bin/sh", "-c", "sleep 5; kill -QUIT 1; sleep {{ your_fpm_process_control_timeout }} "]
 ```
 
 ### Manage PHP-FPM logging

--- a/php/README.md
+++ b/php/README.md
@@ -88,7 +88,6 @@ The following table lists the configurable parameters of the PHP chart and their
 |  `serviceAccount.annotations` | Annotations for the created service account | `{}` |
 |  `serviceAccount.labels` | Labels for the created service account | `{}` |
 |  `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `` |
-|  `extras.templates` | Additional raw Kubernetes resources | `{}` |
 |  `test.enabled` | Enables helm test | `true` |
 
 ### Init containers

--- a/php/templates/NOTES.txt
+++ b/php/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ .path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "php.fullname" . }})

--- a/php/templates/_helpers.tpl
+++ b/php/templates/_helpers.tpl
@@ -62,6 +62,16 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{- define "php.ingress.apiVersion" -}}
+{{- if .Values.ingress.overrideApiVersion -}}
+{{ .Values.ingress.overrideApiVersion }}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+networking.k8s.io/v1beta1
+{{- else -}}
+extensions/v1beta1
+{{- end }}
+{{- end -}}
+
 {{/*
 Create the name of the PSP to use
 */}}

--- a/php/templates/_helpers.tpl
+++ b/php/templates/_helpers.tpl
@@ -75,6 +75,6 @@ extensions/v1beta1
 {{/*
 Create the name of the PSP to use
 */}}
-{{- define "php.pspName" -}}
-{{ .Values.psp.name | default (include "php.fullname" .) }}
+{{- define "php.podSecurityPolicyName" -}}
+{{ .Values.podSecurityPolicy.name | default (include "php.fullname" .) }}
 {{- end -}}

--- a/php/templates/autoscaling.yaml
+++ b/php/templates/autoscaling.yaml
@@ -3,14 +3,23 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "php.fullname" . }}
-  labels: {{ include "php.labels" . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := .Values.autoscaling.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  labels:
+    {{- include "php.labels" . | nindent 4 }}
+    {{- range $k, $v := .Values.autoscaling.labels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  name: {{ include "php.fullname" . }}
 spec:
   scaleTargetRef:
     kind: Deployment
     apiVersion: apps/v1
-    name: {{ template "php.fullname" . }}
+    name: {{ include "php.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  metrics: {{ toYaml .Values.autoscaling.metrics | nindent 4 }}
+  metrics:
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
 {{- end }}

--- a/php/templates/configmap-busybox.yaml
+++ b/php/templates/configmap-busybox.yaml
@@ -1,20 +1,20 @@
 {{- $root := . -}}
 {{- if .Values.busybox.enabled }}
-{{- range $name, $tmpl := .Values.busybox.templates }}
+{{- range $name, $tmpl := .Values.busybox.configMaps }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "php.labels" $root | nindent 4 }}
-  name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
+  name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}
-  {{ $name }}: |
+  {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" }}: |
     {{- tpl $tmpl $root | nindent 4 }}
   {{- else }}
   {{- range $k, $v := $tmpl }}
-  {{ $k }}: {{ tpl $v $root | quote }}
+  {{ $k | replace "/" "-" | replace "_" "-" | replace "." "-" }}: {{ tpl $v $root | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/php/templates/configmap-busybox.yaml
+++ b/php/templates/configmap-busybox.yaml
@@ -5,21 +5,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
-  labels: {{ include "php.labels" $root | nindent 4 }}
-  {{- with $root.Values.busybox.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:
+    {{- include "php.labels" $root | nindent 4 }}
+  name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}
   {{ $name }}: |
-{{ tpl $tmpl $root | indent 4 }}
+    {{- tpl $tmpl $root | nindent 4 }}
   {{- else }}
   {{- range $k, $v := $tmpl }}
-  {{ $k }}: {{ tpl $v $root | toYaml | indent 2 }}
+  {{ $k }}: {{ tpl $v $root | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -4,21 +4,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
-  labels: {{ include "php.labels" $root | nindent 4 }}
-  {{- with $root.Values.fpm.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:
+    {{- include "php.labels" $root | nindent 4 }}
+  name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}
   {{ $name }}: |
-{{ tpl $tmpl $root | indent 4 }}
+    {{- tpl $tmpl $root | nindent 4 }}
   {{- else }}
   {{- range $k, $v := $tmpl }}
-  {{ $k }}: {{ tpl $v $root | toYaml | indent 2 }}
+  {{ $k }}: {{ tpl $v $root | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/php/templates/configmap-fpm.yaml
+++ b/php/templates/configmap-fpm.yaml
@@ -1,19 +1,19 @@
 {{- $root := . -}}
-{{- range $name, $tmpl := .Values.fpm.templates }}
+{{- range $name, $tmpl := .Values.fpm.configMaps }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "php.labels" $root | nindent 4 }}
-  name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
+  name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}
-  {{ $name }}: |
+  {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" }}: |
     {{- tpl $tmpl $root | nindent 4 }}
   {{- else }}
   {{- range $k, $v := $tmpl }}
-  {{ $k }}: {{ tpl $v $root | quote }}
+  {{ $k | replace "/" "-" | replace "_" "-" | replace "." "-" }}: {{ tpl $v $root | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/php/templates/configmap-nginx.yaml
+++ b/php/templates/configmap-nginx.yaml
@@ -5,21 +5,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
-  labels: {{ include "php.labels" $root | nindent 4 }}
-  {{- with $root.Values.nginx.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:
+    {{- include "php.labels" $root | nindent 4 }}
+  name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}
   {{ $name }}: |
-{{ tpl $tmpl $root | indent 4 }}
+    {{- tpl $tmpl $root | nindent 4 }}
   {{- else }}
   {{- range $k, $v := $tmpl }}
-  {{ $k }}: {{ tpl $v $root | toYaml | indent 2 }}
+  {{ $k }}: {{ tpl $v $root | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/php/templates/configmap-nginx.yaml
+++ b/php/templates/configmap-nginx.yaml
@@ -1,20 +1,20 @@
 {{- $root := . -}}
 {{- if .Values.nginx.enabled }}
-{{- range $name, $tmpl := .Values.nginx.templates }}
+{{- range $name, $tmpl := .Values.nginx.configMaps }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "php.labels" $root | nindent 4 }}
-  name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
+  name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
 data:
   {{- if eq (kindOf $tmpl) "string" }}
-  {{ $name }}: |
+  {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" }}: |
     {{- tpl $tmpl $root | nindent 4 }}
   {{- else }}
   {{- range $k, $v := $tmpl }}
-  {{ $k }}: {{ tpl $v $root | quote }}
+  {{ $k | replace "/" "-" | replace "_" "-" | replace "." "-" }}: {{ tpl $v $root | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -88,10 +88,14 @@ spec:
             {{- toYaml .Values.nginx.extraEnv | nindent 12 }}
           envFrom:
             {{- toYaml .Values.nginx.extraEnvFrom | nindent 12 }}
+          {{- with .Values.nginx.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.nginx.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nginx.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.nginx.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.nginx.resources | nindent 12 }}
           lifecycle:
@@ -136,10 +140,14 @@ spec:
             {{- toYaml .Values.fpm.extraEnv | nindent 12 }}
           envFrom:
             {{- toYaml .Values.fpm.extraEnvFrom | nindent 12 }}
+          {{- with .Values.fpm.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.fpm.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.fpm.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.fpm.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.fpm.resources | nindent 12 }}
           lifecycle:

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -197,8 +197,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       readinessGates:
-        {{- range $k, $v := .Values.readinessGates }}
-        - conditionType: {{ $v.conditionType }}
+        {{- range .Values.readinessGates }}
+        - conditionType: {{ .conditionType }}
         {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
       imagePullSecrets:

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -57,6 +57,15 @@ spec:
           volumeMounts:
             - name: share
               mountPath: {{ .Values.busybox.sharedPath | default .Values.sharedPath }}
+            {{- if .Values.busybox.enableAutoMountConfigMap }}
+            {{- range $name, $tmpl := .Values.busybox.configMaps }}
+            {{- if eq (kindOf $tmpl) "string" }}
+            - name: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
+              mountPath: {{ .Values.busybox.sharedPath | default .Values.sharedPath }}/{{ $name }}
+              subPath: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.busybox.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -164,6 +173,15 @@ spec:
         {{- if .Values.busybox.enabled }}
         - name: share
           emptyDir: {}
+        {{- end }}
+        {{- if and .Values.busybox.enabled .Values.busybox.enableAutoMountConfigMap }}
+        {{- range $name, $tmpl := .Values.busybox.configMaps }}
+        {{- if eq (kindOf $tmpl) "string" }}
+        - name: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
+          configMap:
+            name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- with .Values.busybox.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -108,9 +108,9 @@ spec:
             {{- if .Values.nginx.enableAutoMountConfigMap }}
             {{- range $name, $tmpl := .Values.nginx.configMaps }}
             {{- if eq (kindOf $tmpl) "string" }}
-            - name: {{ $name | replace "/" "-" | replace "." "-" | lower }}
+            - name: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
               mountPath: /etc/nginx/{{ $name }}
-              subPath: {{ $name }}
+              subPath: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" }}
             {{- end }}
             {{- end }}
             {{- end }}
@@ -158,9 +158,9 @@ spec:
             {{- if .Values.fpm.enableAutoMountConfigMap }}
             {{- range $name, $tmpl := .Values.fpm.configMaps }}
             {{- if eq (kindOf $tmpl) "string" }}
-            - name: {{ $name | replace "/" "-" | replace "." "-" | lower }}
+            - name: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
               mountPath: /usr/local/etc/{{ $name }}
-              subPath: {{ $name }}
+              subPath: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" }}
             {{- end }}
             {{- end }}
             {{- end }}
@@ -189,9 +189,9 @@ spec:
         {{- if and .Values.nginx.enabled .Values.nginx.enableAutoMountConfigMap }}
         {{- range $name, $tmpl := .Values.nginx.configMaps }}
         {{- if eq (kindOf $tmpl) "string" }}
-        - name: {{ $name | replace "/" "-"  | replace "." "-" | lower }}
+        - name: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
           configMap:
-            name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
+            name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -205,9 +205,9 @@ spec:
         {{- if .Values.fpm.enableAutoMountConfigMap }}
         {{- range $name, $tmpl := .Values.fpm.configMaps }}
         {{- if eq (kindOf $tmpl) "string" }}
-        - name: {{ $name | replace "/" "-"  | replace "." "-" | lower }}
+        - name: {{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
           configMap:
-            name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
+            name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "/" "-" | replace "_" "-" | replace "." "-" | lower }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -96,16 +96,13 @@ spec:
             - name: php-fpm-sock
               mountPath: /var/run/php-fpm
             {{- end }}
-            {{- if not .Values.nginx.disabledDefaultTemplatesMount }}
-            {{- if index .Values.nginx.templates "nginx.conf" }}
-            - name: nginx-conf
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
+            {{- if .Values.nginx.enableAutoMountConfigMap }}
+            {{- range $name, $tmpl := .Values.nginx.configMaps }}
+            {{- if eq (kindOf $tmpl) "string" }}
+            - name: {{ $name | replace "/" "-" | replace "." "-" | lower }}
+              mountPath: /etc/nginx/{{ $name }}
+              subPath: {{ $name }}
             {{- end }}
-            {{- if index .Values.nginx.templates "default.conf" }}
-            - name: default-conf
-              mountPath: /etc/nginx/conf.d/default.conf
-              subPath: default.conf
             {{- end }}
             {{- end }}
             {{- with .Values.nginx.extraVolumeMounts }}
@@ -141,45 +138,22 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.busybox.enabled }}
+            - name: share
+              mountPath: {{ .Values.sharedPath }}
+            {{- end }}
             {{- if not .Values.fpm.containerPort }}
             - name: php-fpm-sock
               mountPath: /var/run/php-fpm
             {{- end }}
-            {{- if not .Values.fpm.disabledDefaultTemplatesMount }}
-            {{- if index .Values.fpm.templates "php.ini" }}
-            - name: php-ini
-              mountPath: /usr/local/etc/php/php.ini
-              subPath: php.ini
-            {{- end }}
-            {{- if index .Values.fpm.templates "php-fpm.conf" }}
-            - name: php-fpm-conf
-              mountPath: /usr/local/etc/php-fpm.conf
-              subPath: php-fpm.conf
-            {{- end }}
-            {{- if index .Values.fpm.templates "www.conf" }}
-            - name: www-conf
-              mountPath: /usr/local/etc/php-fpm.d/www.conf
-              subPath: www.conf
-            {{- end }}
-            {{- if index .Values.fpm.templates "docker.conf" }}
-            - name: docker-conf
-              mountPath: /usr/local/etc/php-fpm.d/docker.conf
-              subPath: docker.conf
-            {{- end }}
-            {{- if index .Values.fpm.templates "zz-docker.conf" }}
-            - name: zz-docker-conf
-              mountPath: /usr/local/etc/php-fpm.d/zz-docker.conf
-              subPath: zz-docker.conf
-            {{- end }}
-            {{- if index .Values.fpm.templates "zz-kubernetes.conf" }}
-            - name: zz-kubernetes-conf
-              mountPath: /usr/local/etc/php-fpm.d/zz-kubernetes.conf
-              subPath: zz-kubernetes.conf
+            {{- if .Values.fpm.enableAutoMountConfigMap }}
+            {{- range $name, $tmpl := .Values.fpm.configMaps }}
+            {{- if eq (kindOf $tmpl) "string" }}
+            - name: {{ $name | replace "/" "-" | replace "." "-" | lower }}
+              mountPath: /usr/local/etc/{{ $name }}
+              subPath: {{ $name }}
             {{- end }}
             {{- end }}
-            {{- if .Values.busybox.enabled }}
-            - name: share
-              mountPath: {{ .Values.sharedPath }}
             {{- end }}
             {{- with .Values.fpm.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -187,63 +161,37 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-        {{- if not .Values.fpm.containerPort }}
-        - name: php-fpm-sock
-          emptyDir: {}
-        {{- end }}
         {{- if .Values.busybox.enabled }}
         - name: share
           emptyDir: {}
         {{- end }}
-        {{- if and .Values.nginx.enabled (not .Values.nginx.disabledDefaultTemplatesMount) }}
-        {{- if index .Values.nginx.templates "nginx.conf" }}
-        - name: nginx-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-nginx-nginx-conf
-        {{- end }}
-        {{- if index .Values.nginx.templates "default.conf" }}
-        - name: default-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-nginx-default-conf
-        {{- end }}
-        {{- end }}
-        {{- if not .Values.fpm.disabledDefaultTemplatesMount }}
-        {{- if index .Values.fpm.templates "php.ini" }}
-        - name: php-ini
-          configMap:
-            name: {{ include "php.fullname" . }}-fpm-php-ini
-        {{- end }}
-        {{- if index .Values.fpm.templates "php-fpm.conf" }}
-        - name: php-fpm-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-fpm-php-fpm-conf
-        {{- end }}
-        {{- if index .Values.fpm.templates "www.conf" }}
-        - name: www-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-fpm-www-conf
-        {{- end }}
-        {{- if index .Values.fpm.templates "docker.conf" }}
-        - name: docker-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-fpm-docker-conf
-        {{- end }}
-        {{- if index .Values.fpm.templates "zz-docker.conf" }}
-        - name: zz-docker-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-fpm-zz-docker-conf
-        {{- end }}
-        {{- if index .Values.fpm.templates "zz-kubernetes.conf" }}
-        - name: zz-kubernetes-conf
-          configMap:
-            name: {{ include "php.fullname" . }}-fpm-zz-kubernetes-conf
-        {{- end }}
-        {{- end }}
         {{- with .Values.busybox.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if and .Values.nginx.enabled .Values.nginx.enableAutoMountConfigMap }}
+        {{- range $name, $tmpl := .Values.nginx.configMaps }}
+        {{- if eq (kindOf $tmpl) "string" }}
+        - name: {{ $name | replace "/" "-"  | replace "." "-" | lower }}
+          configMap:
+            name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.nginx.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if not .Values.fpm.containerPort }}
+        - name: php-fpm-sock
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.fpm.enableAutoMountConfigMap }}
+        {{- range $name, $tmpl := .Values.fpm.configMaps }}
+        {{- if eq (kindOf $tmpl) "string" }}
+        - name: {{ $name | replace "/" "-"  | replace "." "-" | lower }}
+          configMap:
+            name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- with .Values.fpm.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -2,31 +2,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "php.fullname" . }}
+  annotations:
+    {{- range $k, $v := .Values.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
   labels:
     {{- include "php.labels" . | nindent 4 }}
-    {{- with .Values.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := .Values.labels }}
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
-  {{- with .Values.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
-  {{- end }}
+  name: {{ include "php.fullname" . }}
 spec:
-  {{- with .Values.replicaCount }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- with .Values.strategy }}
-  strategy: {{ toYaml . | nindent 4 }}
-  {{- end }}
   selector:
-    matchLabels: {{ include "php.selectorLabels" . | nindent 6 }}
+    matchLabels:
+      {{- include "php.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
   template:
     metadata:
-      labels:
-        {{- include "php.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
       annotations:
         {{- if .Values.busybox.enabled }}
         checksum/configmap-busybox: {{ include (print $.Template.BasePath "/configmap-busybox.yaml") . | sha256sum }}
@@ -39,70 +35,69 @@ spec:
         checksum/configmap-fpm: {{ include (print $.Template.BasePath "/configmap-fpm.yaml") . | sha256sum }}
         checksum/secret-fpm: {{ include (print $.Template.BasePath "/secret-fpm.yaml") . | sha256sum }}
         {{- range $k, $v := .Values.podAnnotations }}
-        {{ $k }}: {{ tpl $v $root | toYaml | indent 8 }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+      labels:
+        {{- include "php.labels" . | nindent 8 }}
+        {{- range $k, $v := .Values.podLabels }}
+        {{ $k }}: {{ $v | quote }}
         {{- end }}
     spec:
       initContainers:
         {{- if .Values.busybox.enabled }}
-        - name: "{{ template "php.fullname" . }}-busybox"
-          image: "{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
+        - name: {{ include "php.fullname" . }}-busybox
+          image: {{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}
           imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
-          command: {{ tpl (toYaml .Values.busybox.command) . | nindent 12 }}
-          {{- with .Values.busybox.extraEnv }}
-          env: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.busybox.extraEnvFrom }}
-          envFrom: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
+          command:
+            {{- toYaml .Values.busybox.command | nindent 12 }}
+          env:
+            {{- toYaml .Values.busybox.extraEnv | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.busybox.extraEnvFrom | nindent 12 }}
           volumeMounts:
             - name: share
               mountPath: {{ .Values.busybox.sharedPath | default .Values.sharedPath }}
             {{- with .Values.busybox.extraVolumeMounts }}
-            {{- tpl (toYaml .) $root | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
-            {{- tpl (toYaml .) $root | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         {{- end }}
       containers:
         {{- if .Values.nginx.enabled }}
-        - name: "{{ template "php.fullname" . }}-nginx"
-          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+        - name: {{ include "php.fullname" . }}-nginx
+          image: {{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
-          command: {{ tpl (toYaml .Values.nginx.command) . | nindent 12 }}
+          command:
+            {{- toYaml .Values.nginx.command | nindent 12 }}
           ports:
             - name: default
               containerPort: {{ .Values.nginx.containerPort }}
               protocol: TCP
             {{- with .Values.nginx.extraPorts }}
-            {{- tpl (toYaml .) $root | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.nginx.extraEnv }}
-          env: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.nginx.extraEnvFrom }}
-          envFrom: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.nginx.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.nginx.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.nginx.resources }}
-          resources: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.nginx.lifecycle }}
-          lifecycle: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
+          env:
+            {{- toYaml .Values.nginx.extraEnv | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.nginx.extraEnvFrom | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.nginx.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.nginx.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.nginx.lifecycle | nindent 12 }}
           volumeMounts:
-            {{- if not .Values.fpm.containerPort }}
-            - name: php-fpm-sock
-              mountPath: /var/run/php-fpm
-            {{- end }}
             {{- if .Values.busybox.enabled }}
             - name: share
               mountPath: {{ .Values.sharedPath }}
+            {{- end }}
+            {{- if not .Values.fpm.containerPort }}
+            - name: php-fpm-sock
+              mountPath: /var/run/php-fpm
             {{- end }}
             {{- if not .Values.nginx.disabledDefaultTemplatesMount }}
             {{- if index .Values.nginx.templates "nginx.conf" }}
@@ -123,39 +118,32 @@ spec:
             {{- tpl (toYaml .) $root | nindent 12 }}
             {{- end }}
         {{- end }}
-        - name: "{{ template "php.fullname" . }}-fpm"
-          image: "{{ .Values.fpm.image.repository }}:{{ .Values.fpm.image.tag }}"
+        - name: {{ include "php.fullname" . }}-fpm
+          image: {{ .Values.fpm.image.repository }}:{{ .Values.fpm.image.tag }}
           imagePullPolicy: {{ .Values.fpm.image.pullPolicy }}
-          {{- with .Values.fpm.command }}
-          command: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- if .Values.fpm.containerPort }}
+          command:
+            {{- toYaml .Values.fpm.command | nindent 12 }}
           ports:
+            {{- if .Values.fpm.containerPort }}
             - name: fcgi
               containerPort: {{ .Values.fpm.containerPort }}
               protocol: TCP
             {{- with .Values.fpm.extraPorts }}
-            {{ tpl (toYaml .) $root | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- end }}
-          {{- with .Values.fpm.extraEnv }}
-          env: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.fpm.extraEnvFrom }}
-          envFrom: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.fpm.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.fpm.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.fpm.resources }}
-          resources: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
-          {{- with .Values.fpm.lifecycle }}
-          lifecycle: {{ tpl (toYaml .) $root | nindent 12 }}
-          {{- end }}
+            {{- end }}
+          env:
+            {{- toYaml .Values.fpm.extraEnv | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.fpm.extraEnvFrom | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.fpm.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.fpm.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.fpm.resources | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.fpm.lifecycle | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
@@ -200,10 +188,10 @@ spec:
               mountPath: {{ .Values.sharedPath }}
             {{- end }}
             {{- with .Values.fpm.extraVolumeMounts }}
-            {{- tpl (toYaml .) $root | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
-            {{- tpl (toYaml .) $root | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: tmp
@@ -220,80 +208,70 @@ spec:
         {{- if index .Values.nginx.templates "nginx.conf" }}
         - name: nginx-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-nginx-nginx-conf'
+            name: {{ include "php.fullname" . }}-nginx-nginx-conf
         {{- end }}
         {{- if index .Values.nginx.templates "default.conf" }}
         - name: default-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-nginx-default-conf'
+            name: {{ include "php.fullname" . }}-nginx-default-conf
         {{- end }}
         {{- end }}
         {{- if not .Values.fpm.disabledDefaultTemplatesMount }}
         {{- if index .Values.fpm.templates "php.ini" }}
         - name: php-ini
           configMap:
-            name: '{{ template "php.fullname" . }}-fpm-php-ini'
+            name: {{ include "php.fullname" . }}-fpm-php-ini
         {{- end }}
         {{- if index .Values.fpm.templates "php-fpm.conf" }}
         - name: php-fpm-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-fpm-php-fpm-conf'
+            name: {{ include "php.fullname" . }}-fpm-php-fpm-conf
         {{- end }}
         {{- if index .Values.fpm.templates "www.conf" }}
         - name: www-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-fpm-www-conf'
+            name: {{ include "php.fullname" . }}-fpm-www-conf
         {{- end }}
         {{- if index .Values.fpm.templates "docker.conf" }}
         - name: docker-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-fpm-docker-conf'
+            name: {{ include "php.fullname" . }}-fpm-docker-conf
         {{- end }}
         {{- if index .Values.fpm.templates "zz-docker.conf" }}
         - name: zz-docker-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-fpm-zz-docker-conf'
+            name: {{ include "php.fullname" . }}-fpm-zz-docker-conf
         {{- end }}
         {{- if index .Values.fpm.templates "zz-kubernetes.conf" }}
         - name: zz-kubernetes-conf
           configMap:
-            name: '{{ template "php.fullname" . }}-fpm-zz-kubernetes-conf'
+            name: {{ include "php.fullname" . }}-fpm-zz-kubernetes-conf
         {{- end }}
         {{- end }}
         {{- with .Values.busybox.extraVolumes }}
-        {{- tpl (toYaml .) $root | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.nginx.extraVolumes }}
-        {{- tpl (toYaml .) $root | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.fpm.extraVolumes }}
-        {{- tpl (toYaml .) $root | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.extraVolumes }}
-        {{- tpl (toYaml .) $root | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.readinessGates }}
       readinessGates:
-        {{- range $k, $v := . }}
-        - conditionType: '{{ tpl $v.conditionType $root }}'
+        {{- range $k, $v := .Values.readinessGates }}
+        - conditionType: {{ $v.conditionType }}
         {{- end }}
-      {{- end }}
-      {{- with .Values.restartPolicy }}
-      restartPolicy: {{ . }}
-      {{- end }}
-      {{- with .Values.imagePullSecrets}}
-      imagePullSecrets: {{ tpl (toYaml .) $root | nindent 8 }}
-      {{- end }}
-      {{- with .Values.securityContext }}
-      securityContext: {{ tpl (toYaml .) $root | nindent 8 }}
-      {{- end }}
-      serviceAccountName: '{{ include "php.serviceAccountName" . }}'
-      {{- with .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ tpl (toYaml .) $root }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity: {{ tpl (toYaml .) $root | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations: {{ tpl (toYaml .) $root | nindent 8 }}
-      {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      serviceAccountName: {{ include "php.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}

--- a/php/templates/deployment.yaml
+++ b/php/templates/deployment.yaml
@@ -60,9 +60,6 @@ spec:
             {{- with .Values.busybox.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- with .Values.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
         {{- end }}
       containers:
         {{- if .Values.nginx.enabled }}
@@ -112,9 +109,6 @@ spec:
             {{- end }}
             {{- end }}
             {{- with .Values.nginx.extraVolumeMounts }}
-            {{- tpl (toYaml .) $root | nindent 12 }}
-            {{- end }}
-            {{- with .Values.extraVolumeMounts }}
             {{- tpl (toYaml .) $root | nindent 12 }}
             {{- end }}
         {{- end }}
@@ -190,9 +184,6 @@ spec:
             {{- with .Values.fpm.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- with .Values.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -255,9 +246,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.fpm.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       readinessGates:

--- a/php/templates/extras.yaml
+++ b/php/templates/extras.yaml
@@ -1,5 +1,0 @@
-{{- $root := . }}
-{{- range $k, $v := .Values.extras.templates }}
----
-{{ tpl $v $root }}
-{{- end }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
           {{- range .extraPathes }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          - path: {{ .path | default "/" }}
+          - path: {{ .path }}
             backend:
               serviceName: {{ include "php.fullname" $root }}
               {{- if $root.Values.nginx.enabled }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -24,8 +24,8 @@ spec:
   tls:
     {{- toYaml .Values.ingress.tls | nindent 4 }}
   rules:
-    {{- range $k, $host := .Values.ingress.hosts }}
-    - host: {{ tpl $host $root }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ tpl .host $root }}
       http:
         paths:
           {{- with $root.Values.ingress.preferPaths }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -1,31 +1,28 @@
 {{- $root := . -}}
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "php.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "php.fullname" . }}
+  annotations:
+    {{- range $k, $v := .Values.ingress.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
   labels:
     {{- include "php.labels" . | nindent 4 }}
-    {{- with .Values.ingress.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := .Values.ingress.labels }}
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  name: {{ include "php.fullname" . }}
 spec:
   backend:
-    serviceName: {{ template "php.fullname" . }}
+    serviceName: {{ include "php.fullname" . }}
     {{- if .Values.nginx.enabled }}
     servicePort: {{ .Values.service.port | default .Values.nginx.containerPort }}
     {{- else }}
     servicePort: {{ .Values.service.port | default .Values.fpm.containerPort }}
     {{- end }}
-  {{- with .Values.ingress.tls }}
-  tls: {{ tpl (toYaml .) $root | nindent 4 }}
-  {{- end }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
   rules:
     {{- range $k, $host := .Values.ingress.hosts }}
     - host: {{ tpl $host $root }}
@@ -36,7 +33,7 @@ spec:
           {{- end }}
           - path: /*
             backend:
-              serviceName: {{ template "php.fullname" $root }}
+              serviceName: {{ include "php.fullname" $root }}
               {{- if $root.Values.nginx.enabled }}
               servicePort: {{ $root.Values.service.port | default $root.Values.nginx.containerPort }}
               {{- else }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -14,24 +14,17 @@ metadata:
     {{- end }}
   name: {{ include "php.fullname" . }}
 spec:
-  backend:
-    serviceName: {{ include "php.fullname" . }}
-    {{- if .Values.nginx.enabled }}
-    servicePort: {{ .Values.service.port | default .Values.nginx.containerPort }}
-    {{- else }}
-    servicePort: {{ .Values.service.port | default .Values.fpm.containerPort }}
-    {{- end }}
   tls:
     {{- toYaml .Values.ingress.tls | nindent 4 }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ tpl .host $root }}
+    - host: {{ .host }}
       http:
         paths:
-          {{- with $root.Values.ingress.preferPaths }}
-          {{- tpl (toYaml .) $root | nindent 10 }}
+          {{- range .extraPathes }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
-          - path: /*
+          - path: {{ .path | default "/" }}
             backend:
               serviceName: {{ include "php.fullname" $root }}
               {{- if $root.Values.nginx.enabled }}

--- a/php/templates/pdb.yaml
+++ b/php/templates/pdb.yaml
@@ -2,15 +2,19 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "php.fullname" . }}
-  labels: {{ include "php.labels" . | nindent 4 }}
+  annotations:
+    {{- range $k, $v := .Values.podDisruptionBudget.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  labels:
+    {{- include "php.labels" . | nindent 4 }}
+    {{- range $k, $v := .Values.podDisruptionBudget.labels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  name: {{ include "php.fullname" . }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "php.selectorLabels" . | nindent 6 }}

--- a/php/templates/psp.yaml
+++ b/php/templates/psp.yaml
@@ -2,16 +2,16 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    {{- range $k, $v := .Values.psp.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
   labels:
     {{- include "php.labels" . | nindent 4 }}
-    {{- with .Values.psp.labels }}
-    {{- toYaml . | nindent 4}}
+    {{- range $k, $v := .Values.psp.labels }}
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
-  annotations:
-    {{- with .Values.psp.annotations }}
-    {{- toYaml . | nindent 4}}
-    {{- end }}
-  name: {{ template "php.pspName" . }}
+  name: {{ include "php.pspName" . }}
 spec:
   privileged: false
   seLinux:
@@ -26,6 +26,6 @@ spec:
     {{- toYaml .Values.psp.volumes | nindent 4 }}
   allowedUnsafeSysctls:
     {{- range .Values.securityContext.sysctls }}
-    - '{{ .name }}'
+    - {{ .name }}
     {{- end }}
 {{- end }}

--- a/php/templates/psp.yaml
+++ b/php/templates/psp.yaml
@@ -1,29 +1,29 @@
-{{- if and .Values.rbac.create .Values.psp.create }}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:
-    {{- range $k, $v := .Values.psp.annotations }}
+    {{- range $k, $v := .Values.podSecurityPolicy.annotations }}
     {{ $k }}: {{ $v | quote }}
     {{- end }}
   labels:
     {{- include "php.labels" . | nindent 4 }}
-    {{- range $k, $v := .Values.psp.labels }}
+    {{- range $k, $v := .Values.podSecurityPolicy.labels }}
     {{ $k }}: {{ $v | quote }}
     {{- end }}
-  name: {{ include "php.pspName" . }}
+  name: {{ include "php.podSecurityPolicyName" . }}
 spec:
   privileged: false
   seLinux:
-    {{- toYaml .Values.psp.seLinux | nindent 4 }}
+    {{- toYaml .Values.podSecurityPolicy.seLinux | nindent 4 }}
   supplementalGroups:
-    {{- toYaml .Values.psp.supplementalGroups | nindent 4 }}
+    {{- toYaml .Values.podSecurityPolicy.supplementalGroups | nindent 4 }}
   runAsUser:
-    {{- toYaml .Values.psp.runAsUser | nindent 4 }}
+    {{- toYaml .Values.podSecurityPolicy.runAsUser | nindent 4 }}
   fsGroup:
-    {{- toYaml .Values.psp.fsGroup | nindent 4 }}
+    {{- toYaml .Values.podSecurityPolicy.fsGroup | nindent 4 }}
   volumes:
-    {{- toYaml .Values.psp.volumes | nindent 4 }}
+    {{- toYaml .Values.podSecurityPolicy.volumes | nindent 4 }}
   allowedUnsafeSysctls:
     {{- range .Values.securityContext.sysctls }}
     - {{ .name }}

--- a/php/templates/role.yaml
+++ b/php/templates/role.yaml
@@ -4,14 +4,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     {{- include "php.labels" . | nindent 4 }}
-  name: "{{ include "php.fullname" . }}"
+  name: {{ include "php.fullname" . }}
 rules:
+  {{- if .Values.psp.create }}
   - apiGroups:
       - policy
     resources:
       - podsecuritypolicies
     resourceNames:
-      - {{ template "php.fullname" . }}
+      - {{ include "php.pspName" . }}
     verbs:
       - use
+  {{- end }}
 {{- end }}

--- a/php/templates/role.yaml
+++ b/php/templates/role.yaml
@@ -6,13 +6,13 @@ metadata:
     {{- include "php.labels" . | nindent 4 }}
   name: {{ include "php.fullname" . }}
 rules:
-  {{- if .Values.psp.create }}
+  {{- if .Values.podSecurityPolicy.create }}
   - apiGroups:
       - policy
     resources:
       - podsecuritypolicies
     resourceNames:
-      - {{ include "php.pspName" . }}
+      - {{ include "php.podSecurityPolicyName" . }}
     verbs:
       - use
   {{- end }}

--- a/php/templates/rolebinding.yaml
+++ b/php/templates/rolebinding.yaml
@@ -4,13 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     {{- include "php.labels" . | nindent 4 }}
-  name: "{{ include "php.fullname" . }}"
+  name: {{ include "php.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "php.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: "{{ include "php.serviceAccountName" . }}"
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ include "php.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/php/templates/secret-busybox.yaml
+++ b/php/templates/secret-busybox.yaml
@@ -5,14 +5,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
-  labels: {{ include "php.labels" $root | nindent 4 }}
-  {{- with $root.Values.busybox.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:
+    {{- include "php.labels" $root | nindent 4 }}
+  name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
 type: Opaque
 data:
   {{- if eq (kindOf $secret) "string" }}

--- a/php/templates/secret-busybox.yaml
+++ b/php/templates/secret-busybox.yaml
@@ -7,7 +7,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "php.labels" $root | nindent 4 }}
-  name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "." "-" | lower }}
+  name: {{ include "php.fullname" $root }}-busybox-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
 type: Opaque
 data:
   {{- if eq (kindOf $secret) "string" }}

--- a/php/templates/secret-fpm.yaml
+++ b/php/templates/secret-fpm.yaml
@@ -4,14 +4,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
-  labels: {{ include "php.labels" $root | nindent 4 }}
-  {{- with $root.Values.fpm.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:
+    {{- include "php.labels" $root | nindent 4 }}
+  name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
 type: Opaque
 data:
   {{- if eq (kindOf $secret) "string" }}

--- a/php/templates/secret-fpm.yaml
+++ b/php/templates/secret-fpm.yaml
@@ -6,7 +6,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "php.labels" $root | nindent 4 }}
-  name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "." "-" | lower }}
+  name: {{ include "php.fullname" $root }}-fpm-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
 type: Opaque
 data:
   {{- if eq (kindOf $secret) "string" }}

--- a/php/templates/secret-nginx.yaml
+++ b/php/templates/secret-nginx.yaml
@@ -7,7 +7,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "php.labels" $root | nindent 4 }}
-  name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
+  name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "/" "-"  | replace "." "-" | lower }}
 type: Opaque
 data:
   {{- if eq (kindOf $secret) "string" }}

--- a/php/templates/secret-nginx.yaml
+++ b/php/templates/secret-nginx.yaml
@@ -5,14 +5,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
-  labels: {{ include "php.labels" $root | nindent 4 }}
-  {{- with $root.Values.nginx.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  labels:
+    {{- include "php.labels" $root | nindent 4 }}
+  name: {{ include "php.fullname" $root }}-nginx-{{ $name | replace "." "-" | lower }}
 type: Opaque
 data:
   {{- if eq (kindOf $secret) "string" }}

--- a/php/templates/service.yaml
+++ b/php/templates/service.yaml
@@ -2,18 +2,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "php.fullname" . }}
+  annotations:
+    {{- range $k, $v := .Values.service.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
   labels:
     {{- include "php.labels" . | nindent 4 }}
-    {{- with .Values.service.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := .Values.service.labels }}
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
-  {{- with .Values.service.annotations }}
-  annotations:
-    {{- range $k, $v := . }}
-    {{ $k }}: {{ tpl $v $root | toYaml | indent 4 }}
-    {{- end }}
-  {{- end }}
+  name: {{ include "php.fullname" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -28,4 +26,5 @@ spec:
     {{- with .Values.service.extraPorts }}
     {{- tpl (toYaml .) $root | nindent 4 }}
     {{- end }}
-  selector: {{ include "php.selectorLabels" . | nindent 4 }}
+  selector:
+    {{- include "php.selectorLabels" . | nindent 4 }}

--- a/php/templates/serviceaccount.yaml
+++ b/php/templates/serviceaccount.yaml
@@ -1,13 +1,15 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- range $k, $v := .Values.serviceAccount.annotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
   labels:
     {{- include "php.labels" . | nindent 4 }}
-    {{- with .Values.serviceAccount.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $k, $v := .Values.serviceAccount.labels }}
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
-  name: "{{ include "php.serviceAccountName" . }}"
-{{- end -}}
+  name: {{ include "php.serviceAccountName" . }}
+{{- end }}

--- a/php/templates/test/test-pod.yaml
+++ b/php/templates/test/test-pod.yaml
@@ -15,8 +15,11 @@ spec:
       command:
         - /bin/sh
         - -c
-        - |
-          curl http://{{ template "php.fullname" . }}:{{ .Values.service.port | default .Values.nginx.containerPort }}
+        {{- if .Values.nginx.enabled }}
+        - 'curl http://{{ template "php.fullname" . }}:{{ .Values.service.port | default .Values.nginx.containerPort }}'
+        {{- else }}
+        - 'curl http://{{ template "php.fullname" . }}:{{ .Values.service.port | default .Values.fpm.containerPort }}'
+        {{- end }}
     {{- with .Values.test.extraContainer }}
     {{- toYaml . | nindent 4}}
     {{- end }}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -434,24 +434,6 @@ fpm:
   # Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets`.
   annotations: {}
 
-# `extra` is additional Raw Kubernetes Config as a string to be passed to the tpl function.
-extras:
-  templates: {}
-#    secret1: |
-#     apiVersion: v1
-#     kind: Secret
-#     metadata:
-#       name: {{ template "php.fullname" . }}
-#       labels:
-#         app: {{ template "php.name" . }}
-#         chart: {{ template "php.chart" . }}
-#         release: {{ .Release.Name }}
-#         heritage: {{ .Release.Service }}
-#     type: Opaque
-#     data:
-#       hoge: {{ .Values.extras.hoge }}
-#  hoge: 1
-
 # TEST
 test:
   enabled: true

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -118,7 +118,7 @@ busybox:
   #sharedPath: /var/www/html
 
   # `busybox.extraEnv` is additional environment variables.
-  extraEnv: {}
+  extraEnv: []
   #  KEY1: VALUE1
   #  KEY2: VALUE2
   #  KEY3: VALUE3
@@ -221,7 +221,7 @@ nginx:
   resources: {}
 
   # `nginx.extraEnv` is additional environment variables.
-  extraEnv: {}
+  extraEnv: []
   #  KEY1: VALUE1
   #  KEY2: VALUE2
   #  KEY3: VALUE3

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -161,7 +161,7 @@ busybox:
 
   # `buxybox.templates` is additional ConfigMap as a string to be passed to the tpl function.
   # ConfigMap name created here is `[release-name]-busybox-[template-name]`.
-  templates: {}
+  configMaps: {}
   #  file1.yaml: |
   #    foo: 1
   #    bar: 2
@@ -174,9 +174,6 @@ busybox:
   #    FOO: 1
   #    BAR: 2
   #    BAZ: 3
-
-  # Grant annotations to ConfigMap of `busybox.templates`, Secrets of `busybox.secrets`.
-  annotations: {}
 
 # NGINX
 nginx:
@@ -272,13 +269,11 @@ nginx:
   #    BAR: 2
   #    BAZ: 3
 
-  # If true, do not mount the templates to the pod.
-  # This is for use in environment variables only, or to include when building containers.
-  disabledDefaultTemplatesMount: false
+  enableAutoMountConfigMap: true
 
   # configuration NGINX templates.
   # If you can not be satisfied with the default settings you can change the template.
-  templates:
+  configMaps:
     nginx.conf: |
       user  nobody;
       worker_processes  auto;
@@ -306,7 +301,7 @@ nginx:
 
           include /etc/nginx/conf.d/*.conf;
       }
-    default.conf: |
+    conf.d/default.conf: |
       server {
           listen {{ .Values.nginx.containerPort }};
 
@@ -322,9 +317,6 @@ nginx:
               include        fastcgi_params;
           }
       }
-
-  # Grant annotations to ConfigMap of `nginx.templates`, Secrets of `nginx.secrets`.
-  annotations: {}
 
 # PHP-FPM
 fpm:
@@ -406,14 +398,12 @@ fpm:
   #    BAR: 2
   #    BAZ: 3
 
-  # If true, do not mount the templates to the pod.
-  # This is for use in environment variables only, or to include when building containers.
-  disabledDefaultTemplatesMount: false
+  enableAutoMountConfigMap: true
 
   # configuration PHP-FPM templates
   # If you can not be satisfied with the default settings you can change the template.
-  templates:
-    zz-kubernetes.conf: |
+  configMaps:
+    php-fpm.d/zz-kubernetes.conf: |
       [www]
       {{- if .Values.fpm.containerPort }}
       listen = 127.0.0.1:{{ .Values.fpm.containerPort }}
@@ -430,9 +420,6 @@ fpm:
       php_admin_value[error_log] = /proc/self/fd/2
       php_admin_flag[log_errors] = on
       php_admin_value[log_errors_max_len] = 8192
-
-  # Grant annotations to ConfigMap of `fpm.templates`, Secrets of `fpm.secrets`.
-  annotations: {}
 
 # TEST
 test:

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -37,21 +37,37 @@ affinity: {}
 
 # SERVICE
 service:
-  type: LoadBalancer
-  port: 80
-  extraPorts: []
-  labels: {}
   annotations: {}
+  labels: {}
+  type: LoadBalancer
+  port: null
+  extraPorts: []
 
 # INGRESS
 ingress:
   enabled: false
   labels: {}
   annotations: {}
+  hosts: []
+  # - host: localhost
+  #   path: /
+  #   extraPathes:
+  #     path: /foo
+  #     backend:
+  #       serviceName: foo-service
+  #       servicePort: 80
+  tls: []
+  # - hosts:
+  #     - example.com
+  #       secretName: examplecret-tls
 
 # PDB
 podDisruptionBudget:
   enabled: false
+  annotations: {}
+  labels: {}
+  minAvailabled:
+  maxAvailabled:
 
 # HPA
 autoscaling:
@@ -116,7 +132,7 @@ busybox:
 
   # `busybox.sharedPath` is specifies the directory to mount.
   # Default is `sharedPath`, but if it conflicts with the source code directory, please specify it.
-  #sharedPath: /var/www/html
+  sharedPath:
 
   # `busybox.extraEnv` is additional environment variables.
   extraEnv: []
@@ -160,18 +176,21 @@ busybox:
   #    BAR: 2
   #    BAZ: 3
 
-  # `buxybox.templates` is additional ConfigMap as a string to be passed to the tpl function.
+  # If true, ConfigMap will be volume-mounted to the pod automatically.
+  enableAutoMountConfigMap: true
+
+  # `buxybox.configMaps` is additional ConfigMap as a string to be passed to the tpl function.
   # ConfigMap name created here is `[release-name]-busybox-[template-name]`.
   configMaps: {}
-  #  file1.yaml: |
+  #  template-name1.yaml: |
   #    foo: 1
   #    bar: 2
   #    baz: 3
-  #  file2.yaml: |
+  #  template-name2.yaml: |
   #    foo: 1
   #    bar: 2
   #    baz: 3
-  #  envname:
+  #  template-name3:
   #    FOO: 1
   #    BAR: 2
   #    BAZ: 3
@@ -201,7 +220,7 @@ nginx:
 
   livenessProbe:
     httpGet:
-      path: /index.php
+      path: /
       port: 80
     initialDelaySeconds: 15
     periodSeconds: 5
@@ -211,7 +230,7 @@ nginx:
 
   readinessProbe:
     httpGet:
-      path: /index.php
+      path: /
       port: 80
     initialDelaySeconds: 15
     periodSeconds: 5
@@ -270,6 +289,7 @@ nginx:
   #    BAR: 2
   #    BAZ: 3
 
+  # If true, ConfigMap will be volume-mounted to the pod automatically.
   enableAutoMountConfigMap: true
 
   # configuration NGINX templates.
@@ -399,6 +419,7 @@ fpm:
   #    BAR: 2
   #    BAZ: 3
 
+  # If true, ConfigMap will be volume-mounted to the pod automatically.
   enableAutoMountConfigMap: true
 
   # configuration PHP-FPM templates

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -11,6 +11,8 @@ sharedPath: /var/www/html
 strategy:
   type: RollingUpdate
 
+annotations: {}
+
 labels: {}
 
 podLabels: {}
@@ -21,7 +23,7 @@ imagePullSecrets: []
 
 readinessGates: {}
 
-restartPolicy: ""
+restartPolicy: "Always"
 
 securityContext: {}
 
@@ -57,9 +59,11 @@ podDisruptionBudget:
 # HPA
 autoscaling:
   enabled: false
-  #minReplicas:
-  #maxReplicas:
-  #metrics:
+  annotations: {}
+  labels: {}
+  minReplicas:
+  maxReplicas:
+  metrics: {}
   #  - type: Resource
   #    resource:
   #      name: cpu
@@ -111,11 +115,11 @@ busybox:
   # `busybox.command` is initialize command.
   # Copy the source code in busybox to `sharedPath` or `busybox.sharedPath`.
   # e.g. sh -c "cp -av /path/to/sources/* /path/to/share-path"
-  command: ["sh", "-c", "echo '<?php echo \"Hello World\";' > {{ .Values.sharedPath }}/index.php"]
+  command: ["sh", "-c", "echo '<?php echo \"Hello World\";' > /var/www/html/index.php"]
 
   # `busybox.sharedPath` is specifies the directory to mount.
   # Default is `sharedPath`, but if it conflicts with the source code directory, please specify it.
-  #sharedPath: {{ .Values.sharedPath }}
+  #sharedPath: /var/www/html
 
   # `busybox.extraEnv` is additional environment variables.
   extraEnv: {}

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -66,8 +66,8 @@ podDisruptionBudget:
   enabled: false
   annotations: {}
   labels: {}
-  minAvailabled:
-  maxAvailabled:
+  minAvailable:
+  maxUnavailable:
 
 # HPA
 autoscaling:

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -6,7 +6,7 @@
 sharedPath: /var/www/html
 
 # DEPLOYMENT
-#replicaCount: 1
+replicaCount: 1
 
 strategy:
   type: RollingUpdate

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -29,10 +29,6 @@ securityContext: {}
 
 serviceAccountName: ""
 
-extraVolumes: []
-
-extraVolumeMounts: []
-
 terminationGracePeriodSeconds: 70
 
 tolerations: []

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -38,6 +38,7 @@ affinity: {}
 # SERVICE
 service:
   type: LoadBalancer
+  port: 80
   extraPorts: []
   labels: {}
   annotations: {}
@@ -307,7 +308,7 @@ nginx:
 
           location / {
               root   {{ .Values.sharedPath }};
-              index  index.html index.htm;
+              index  index.php index.html index.htm;
           }
           location ~ \.php$ {
               root           {{ .Values.sharedPath }};

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -73,7 +73,7 @@ rbac:
   create: true
 
 # PSP
-psp:
+podSecurityPolicy:
   create: false
   annotations: {}
   labels: {}


### PR DESCRIPTION
For PHP v1, we made some simplifying changes to the specifications. 

**Breaking Change**

- Changed to expand `tpl` only in ConfigMap/Secret
-A key name for the `values.yaml` has been altered 
    - `psp` -> `podSecurityPolicy`
    - `busybox.disabledDefaultTemplatesMount` -> `busybox.enableAutoMountConfigMap`
    - `busybox.templates` -> `busyboxy.configMaps`
    - `ingress.preferPaths` -> `ingress.hosts.extraPaths`
- Changed to ignore `replicaCount` when Autoscaling is enabled
- Changed the naming scheme for ConfigMap/Secret
- Change the version of ingress to match kubernetes version
    - Specify the `ingress.overrideApiVersion` if you want to use a specific version of ingress API
- Changed to allow you to specify the path of Ingress
- Change to specify PSP use for Rule rule only when PSP is enabled
- Remove `extras`
- Other values that had injection problems were changed

#### Checklist

- [X] Chart Version bumped


