### PR TITLE
[mailcatcher] create mailcatcher chart

### DIFF
--- a/mailcatcher/.helmignore
+++ b/mailcatcher/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+templates/test/test-hostPath-values.yaml

--- a/mailcatcher/Chart.yaml
+++ b/mailcatcher/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: mailcatcher
+description: Catches mail and serves it through a dream
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.7.1

--- a/mailcatcher/Makefile
+++ b/mailcatcher/Makefile
@@ -1,0 +1,13 @@
+RELEASE = "$$(basename $$PWD)"
+
+.PHONY: install
+install:
+	helm upgrade -i --wait --set service.type=NodePort $(RELEASE) .
+
+.PHONY: test
+test:
+	echo "no test"
+
+.PHONY: uninstall
+uninstall:
+	helm uninstall $(RELEASE)

--- a/mailcatcher/templates/_helpers.tpl
+++ b/mailcatcher/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mailcatcher.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mailcatcher.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mailcatcher.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "mailcatcher.labels" -}}
+helm.sh/chart: {{ include "mailcatcher.chart" . }}
+{{ include "mailcatcher.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "mailcatcher-mailcatcher.labels" -}}
+helm.sh/chart: {{ include "mailcatcher.chart" . }}
+{{ include "mailcatcher-mailcatcher.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mailcatcher.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mailcatcher.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "mailcatcher-mailcatcher.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mailcatcher.name" . }}-mailcatcher
+app.kubernetes.io/instance: {{ .Release.Name }}-mailcatcher
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mailcatcher.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "mailcatcher.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/mailcatcher/templates/deployment.yaml
+++ b/mailcatcher/templates/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "mailcatcher-mailcatcher.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "mailcatcher.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mailcatcher-mailcatcher.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "mailcatcher-mailcatcher.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      containers:
+        - command:
+            - mailcatcher
+            - --foreground
+            {{- with .Values.mailcatcher.ip }}
+            - --ip
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mailcatcher.smtpIp }}
+            - --smtp-ip
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mailcatcher.smtpPort }}
+            - --smtp-port
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mailcatcher.httpIp }}
+            - --http-ip
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mailcatcher.httpPort }}
+            - --http-port
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mailcatcher.httpPath }}
+            - --http-path
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.mailcatcher.noQuit }}
+            - --no-quit
+            {{- end }}
+            {{- if .Values.mailcatcher.verbose }}
+            - --verbose
+            {{- end }}
+            {{- with .Values.extraCmmand }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          name: {{ include "mailcatcher.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: smtp
+              containerPort: {{ .Values.mailcatcher.smtpPort }}
+              protocol: TCP
+            - name: http
+              containerPort: {{ .Values.mailcatcher.httpPort }}
+              protocol: TCP
+            {{- with .Values.extraPorts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe| nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      readinessGates:
+        {{- toYaml .Values.readinessGates | nindent 8 }}
+      restartPolicy: "{{ .Values.restartPolicy }}"
+      priorityClassName: {{ .Values.priorityClassName }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: "{{ include "mailcatcher.serviceAccountName" . }}"
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/mailcatcher/templates/service.yaml
+++ b/mailcatcher/templates/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "mailcatcher-mailcatcher.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "mailcatcher.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.mailcatcher.smtpPort }}
+      targetPort: smtp
+      protocol: TCP
+      name: smtp
+    - port: {{ .Values.service.port | default .Values.mailcatcher.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mailcatcher-mailcatcher.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/mailcatcher/templates/serviceaccount.yaml
+++ b/mailcatcher/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  labels:
+    {{- include "mailcatcher.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: "{{ include "mailcatcher.serviceAccountName" . }}"
+{{- end -}}

--- a/mailcatcher/values.yaml
+++ b/mailcatcher/values.yaml
@@ -1,0 +1,141 @@
+# Default values for postfix.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: chatwork/mailcatcher
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+mailcatcher:
+  # Set the ip address of both servers
+  ip: 0.0.0.0
+  # Set the ip address of the smtp server
+  smtpIp:
+  # Set the port of the smtp server
+  smtpPort: 1025
+  # Set the ip address of the http server
+  httpIp:
+  # Set the port address of the http server
+  httpPort: 1080
+  # Add a prefix to all HTTP paths
+  httpPath:
+  # Don't allow quitting the process
+  noQuit:
+  # Be more verbose
+  verbose:
+
+affinity: {}
+
+annotations: {}
+
+env: []
+  # - name: DEMO_GREETING
+  #   value: "Hello from the environment"
+
+envFrom: []
+  # - configMapRef:
+  #     name: special-config
+
+extraCmmand: []
+
+extraPorts: []
+  #- name: extra-port
+  #  containerPort: 9999
+  #  protocol: TCP
+
+extraVolumes: []
+  # - name: volime-name
+  #   hostPath:
+  #     path: /path/to
+
+extraVolumeMounts: []
+  # - name: volume-name
+  #   mountPath: /path/to
+
+imagePullSecrets: []
+
+labels: {}
+
+lifecycle: {}
+
+livenessProbe:
+  httpGet:
+    port: 1080
+    path: /
+    scheme: HTTP
+  failureThreshold: 2
+  initialDelaySeconds: 10
+  periodSeconds: 60
+
+nodeSelector: {}
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+priorityClassName: ""
+
+readinessGates: []
+
+readinessProbe:
+  httpGet:
+    port: 1080
+    path: /
+    scheme: HTTP
+  failureThreshold: 2
+  periodSeconds: 5
+
+replicaCount: 1
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+restartPolicy: Always
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+strategy: {}
+
+terminationGracePeriodSeconds: 60
+
+tolerations: []
+
+# SA Configuration
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Annotations to add to the service account.
+  annotations: {}
+  labels: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name:
+
+service:
+  enabled: true
+  annotations: []
+  labels: []
+  type: LoadBalancer
+  port: 1080


### PR DESCRIPTION
I made a simple chart for the [mailcatcher](https://mailcatcher.me/).
The reason for this is that it was originally included in postfix chart, but there was a use case where we wanted to install it separately.

#### Checklist

- [X] Chart Version bumped


