### PR TITLE
[php] remove default probe

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/README.md
+++ b/php/README.md
@@ -128,8 +128,8 @@ We recommend that you embed the source code in your container and copy it to the
 |  `nginx.command` | Command to execute | `[]` |
 |  `nginx.containerPort` | Listen port of NGINX container | `80` |
 |  `nginx.lifecycle` | NGINX container lifecycle hooks | `{}` |
-|  `nginx.livenessProbe` | Liveness probe settings | `{ "httpGet": { "path": "/", "port": 80 } "initialDelaySeconds": 15, "periodSeconds": 5, "timeoutSeconds": 1, "successThreshold": 1, "failureThreshold": 3 }` |
-|  `nginx.readinessProbe` | Readiness probe settings | `{ "httpGet": { "path": "/", "port": 80 } "initialDelaySeconds": 15, "periodSeconds": 5, "timeoutSeconds": 1, "successThreshold": 1, "failureThreshold": 3 }` |
+|  `nginx.livenessProbe` | Liveness probe settings | `{}` |
+|  `nginx.readinessProbe` | Readiness probe settings | `{}` |
 |  `nginx.startupProbe` | Startup probes settings. This feature is available since 1.18 | `{}` |
 |  `nginx.resources` | NGINX resources requests & limits | `[]` |
 |  `nginx.extraEnv` | Additional environment variables | `{}` |

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -234,35 +234,11 @@ nginx:
     #  exec:
     #    command: ["/bin/sh", "-c", "sleep 5; nginx -s quit; sleep 60"]
 
-  livenessProbe:
-    httpGet:
-      path: /
-      port: 80
-    initialDelaySeconds: 15
-    periodSeconds: 5
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 3
+  livenessProbe: {}
 
-  readinessProbe:
-    httpGet:
-      path: /
-      port: 80
-    initialDelaySeconds: 15
-    periodSeconds: 5
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 3
+  readinessProbe: {}
 
-  startupProbe:
-    httpGet:
-      path: /
-      port: 80
-    initialDelaySeconds: 15
-    periodSeconds: 5
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 3
+  startupProbe: {}
 
   resources: {}
 


### PR DESCRIPTION
Removed the default value in NGINX Readines/Liveness/Startup Probe.
This is because NGINX does not allow you to remove probe.

#### Checklist

- [X] Chart Version bumped


