### PR TITLE
[aws-ebs-csi-driver]Update containers

### DIFF
--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.7.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
 version: 0.1.3
-kubeVersion: ">=1.14.0-0"
+kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:
   - https://github.com/kubernetes-sigs/aws-ebs-csi-driver

--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.7.0"
+appVersion: "0.7.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.1.2
+version: 0.1.3
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/aws-ebs-csi-driver/README.md
+++ b/aws-ebs-csi-driver/README.md
@@ -36,7 +36,8 @@ The following table lists the configurable parameters of the Aws-ebs-csi-driver 
 | `csiProvisoner.image.tag` | Image tag   | `"v1.6.0"` |
 | `csiProvisoner.image.pullPolicy` | Image pullPolicy  | `"Always"` |
 | `csiProvisoner.resources` | Set resources   | `{}` |
-| `csiProvisoner.leaderElection` | If true, enable leader-election | `true` |
+| `csiProvisoner.leaderElection.enabled` | If true, enable leader-election | `true` |
+| `csiProvisoner.leaderElection.namespace` | leader-election namespace | `""` |
 | `csiProvisoner.logLevel` | Set log-level  | `5` |
 | `csiProvisoner.extraArgs` | Set extraArgs https://github.com/kubernetes-csi/external-provisioner#command-line-options | `[]` |
 | `csiAttacher.image.repository` | Image repository | `"quay.io/k8scsi/csi-attacher"` |

--- a/aws-ebs-csi-driver/templates/controller.yaml
+++ b/aws-ebs-csi-driver/templates/controller.yaml
@@ -95,9 +95,11 @@ spec:
             {{- if .Values.enableVolumeScheduling }}
             - --feature-gates=Topology=true
             {{- end}}
-            {{- if .Values.csiProvisoner.leaderElection }}
-            - --enable-leader-election
-            - --leader-election-type=leases
+            {{- if .Values.csiProvisoner.leaderElection.enabled }}
+            - --leader-election
+            {{- end }}
+            {{- with .Values.csiProvisoner.leaderElection.namespace }}
+            - --leader-election-namespace={{ . }}
             {{- end }}
             {{- with .Values.csiProvisoner.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-ebs-csi-driver
-  tag: "v0.7.0"
+  tag: "v0.7.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -37,17 +37,19 @@ region: ""
 csiProvisoner:
   image:
     repository: quay.io/k8scsi/csi-provisioner
-    tag: "v1.6.0"
+    tag: "v2.1.0"
     pullPolicy: Always
   resources: {}
-  leaderElection: true
+  leaderElection:
+    enabled: true
+    namespace: ""
   logLevel: 5
   extraArgs: []
 
 csiAttacher:
   image:
     repository: quay.io/k8scsi/csi-attacher
-    tag: "v3.0.2"
+    tag: "v3.1.0"
     pullPolicy: Always
   resources: {}
   leaderElection: true
@@ -57,7 +59,7 @@ csiAttacher:
 csiResizer:
   image:
     repository: quay.io/k8scsi/csi-resizer
-    tag: "v1.0.1"
+    tag: "v1.1.0"
     pullPolicy: Always
   resources: {}
   logLevel: 5
@@ -67,7 +69,7 @@ csiResizer:
 csiSnapshotter:
   image:
     repository: quay.io/k8scsi/csi-snapshotter
-    tag: "v3.0.2"
+    tag: "v3.0.3"
     pullPolicy: Always
   leaderElection: true
   extraArgs: []
@@ -76,14 +78,14 @@ csiSnapshotter:
 livenessProbe:
   image:
     repository: quay.io/k8scsi/livenessprobe
-    tag: "v2.1.0"
+    tag: "v2.2.0"
     pullPolicy: Always
   resources: {}
 
 nodeDriverRegistrar:
   image:
     repository: quay.io/k8scsi/csi-node-driver-registrar
-    tag: "v2.0.1"
+    tag: "v2.1.0"
     pullPolicy: Always
   resources: {}
   extraArgs: []
@@ -146,7 +148,7 @@ controller:
 snapshotController:
   image:
     repository: quay.io/k8scsi/snapshot-controller
-    tag: "v3.0.0"
+    tag: "v3.0.3"
     pullPolicy: Always
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
- bump some versions
- modified csi-provisioner parameter for v2
  - https://github.com/kubernetes-csi/external-provisioner/releases
  -  The v1 version of csi-provisinor is compatible up to 1.18, so change to v2.

#### Checklist

- [x] Chart Version bumped


