### PR TITLE
enable the --strict option in kubeval

### DIFF
--- a/akka/Makefile
+++ b/akka/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-local-akka-http
@@ -23,42 +23,42 @@ lint-local-akka-http:
 	@echo "=> Linting examples/local-akka-http.yaml"
 	helm lint --strict -f examples/local-akka-http.yaml
 	@echo "=> Validating examples/local-akka-http.yaml"
-	helm template -f examples/local-akka-http.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/local-akka-http.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-discovery-dns
 lint-cluster-discovery-dns:
 	@echo "=> Linting examples/cluster-discovery-dns.yaml"
 	helm lint --strict -f examples/cluster-discovery-dns.yaml
 	@echo "=> Validating examples/cluster-discovery-dns.yaml"
-	helm template -f examples/cluster-discovery-dns.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-discovery-dns.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-discovery-kubernetes-api
 lint-cluster-discovery-kubernetes-api:
 	@echo "=> Linting examples/cluster-discovery-kubernetes-api.yaml"
 	helm lint --strict -f examples/cluster-discovery-kubernetes-api.yaml
 	@echo "=> Validating examples/cluster-discovery-kubernetes-api.yaml"
-	helm template -f examples/cluster-discovery-kubernetes-api.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-discovery-kubernetes-api.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-discovery-aggregate
 lint-cluster-discovery-aggregate:
 	@echo "=> Linting examples/cluster-discovery-aggregate.yaml"
 	helm lint --strict -f examples/cluster-discovery-aggregate.yaml
 	@echo "=> Validating examples/cluster-discovery-aggregate.yaml"
-	helm template -f examples/cluster-discovery-aggregate.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-discovery-aggregate.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-multi-eks-cluster
 lint-cluster-multi-eks-cluster:
 	@echo "=> Linting examples/cluster-multi-eks-cluster.yaml"
 	helm lint --strict -f examples/cluster-multi-eks-cluster.yaml
 	@echo "=> Validating examples/cluster-multi-eks-cluster.yaml"
-	helm template -f examples/cluster-multi-eks-cluster.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-multi-eks-cluster.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-use-environment-variable-and-secret
 lint-use-environment-variable-and-secret:
 	@echo "=> Linting examples/use-environment-variable-and-secret.yaml"
 	helm lint --strict -f examples/use-environment-variable-and-secret.yaml
 	@echo "=> Validating examples/use-environment-variable-and-secret.yaml"
-	helm template -f examples/use-environment-variable-and-secret.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/use-environment-variable-and-secret.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: test
 test: test-local-akka-http test-cluster-discovery-dns test-cluster-discovery-kubernetes-api test-use-environment-variable-and-secret test-default

--- a/akka/Makefile
+++ b/akka/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas  --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-local-akka-http
@@ -23,42 +23,42 @@ lint-local-akka-http:
 	@echo "=> Linting examples/local-akka-http.yaml"
 	helm lint --strict -f examples/local-akka-http.yaml
 	@echo "=> Validating examples/local-akka-http.yaml"
-	helm template -f examples/local-akka-http.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/local-akka-http.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-discovery-dns
 lint-cluster-discovery-dns:
 	@echo "=> Linting examples/cluster-discovery-dns.yaml"
 	helm lint --strict -f examples/cluster-discovery-dns.yaml
 	@echo "=> Validating examples/cluster-discovery-dns.yaml"
-	helm template -f examples/cluster-discovery-dns.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-discovery-dns.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-discovery-kubernetes-api
 lint-cluster-discovery-kubernetes-api:
 	@echo "=> Linting examples/cluster-discovery-kubernetes-api.yaml"
 	helm lint --strict -f examples/cluster-discovery-kubernetes-api.yaml
 	@echo "=> Validating examples/cluster-discovery-kubernetes-api.yaml"
-	helm template -f examples/cluster-discovery-kubernetes-api.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-discovery-kubernetes-api.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-discovery-aggregate
 lint-cluster-discovery-aggregate:
 	@echo "=> Linting examples/cluster-discovery-aggregate.yaml"
 	helm lint --strict -f examples/cluster-discovery-aggregate.yaml
 	@echo "=> Validating examples/cluster-discovery-aggregate.yaml"
-	helm template -f examples/cluster-discovery-aggregate.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-discovery-aggregate.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-cluster-multi-eks-cluster
 lint-cluster-multi-eks-cluster:
 	@echo "=> Linting examples/cluster-multi-eks-cluster.yaml"
 	helm lint --strict -f examples/cluster-multi-eks-cluster.yaml
 	@echo "=> Validating examples/cluster-multi-eks-cluster.yaml"
-	helm template -f examples/cluster-multi-eks-cluster.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/cluster-multi-eks-cluster.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-use-environment-variable-and-secret
 lint-use-environment-variable-and-secret:
 	@echo "=> Linting examples/use-environment-variable-and-secret.yaml"
 	helm lint --strict -f examples/use-environment-variable-and-secret.yaml
 	@echo "=> Validating examples/use-environment-variable-and-secret.yaml"
-	helm template -f examples/use-environment-variable-and-secret.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/use-environment-variable-and-secret.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: test
 test: test-local-akka-http test-cluster-discovery-dns test-cluster-discovery-kubernetes-api test-use-environment-variable-and-secret test-default

--- a/argoproj-crd/Makefile
+++ b/argoproj-crd/Makefile
@@ -17,6 +17,9 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo ""
+	@echo "=> Validating default value.yaml"
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	@echo ""
 
 .PHONY: test
 test:

--- a/aws-alb-ingress-controller/Makefile
+++ b/aws-alb-ingress-controller/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/aws-alb-ingress-controller/Makefile
+++ b/aws-alb-ingress-controller/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/aws-ebs-csi-driver/Makefile
+++ b/aws-ebs-csi-driver/Makefile
@@ -16,7 +16,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/aws-ebs-csi-driver/Makefile
+++ b/aws-ebs-csi-driver/Makefile
@@ -16,7 +16,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/aws-secret-operator/Makefile
+++ b/aws-secret-operator/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/aws-secret-operator/Makefile
+++ b/aws-secret-operator/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/burrow/Makefile
+++ b/burrow/Makefile
@@ -17,7 +17,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/burrow/Makefile
+++ b/burrow/Makefile
@@ -17,7 +17,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/contour/Makefile
+++ b/contour/Makefile
@@ -17,7 +17,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/contour/Makefile
+++ b/contour/Makefile
@@ -17,7 +17,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/dynamodb/Makefile
+++ b/dynamodb/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/dynamodb/Makefile
+++ b/dynamodb/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/elasticmq/Makefile
+++ b/elasticmq/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/elasticmq/Makefile
+++ b/elasticmq/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/elasticsearch/Makefile
+++ b/elasticsearch/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/elasticsearch/Makefile
+++ b/elasticsearch/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/example/Makefile
+++ b/example/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/example/Makefile
+++ b/example/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/fluent-bit/Makefile
+++ b/fluent-bit/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/fluent-bit/Makefile
+++ b/fluent-bit/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/fluentd/Makefile
+++ b/fluentd/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-daemonset
@@ -23,21 +23,21 @@ lint-daemonset:
 	@echo "=> Linting examples/daemonset.yaml"
 	helm lint --strict -f examples/daemonset.yaml
 	@echo "=> Validating examples/daemonset.yaml"
-	helm template -f examples/daemonset.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/daemonset.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-statefulset
 lint-statefulset:
 	@echo "=> Linting examples/statefulset.yaml"
 	helm lint --strict -f examples/statefulset.yaml
 	@echo "=> Validating examples/statefulset.yaml"
-	helm template -f examples/statefulset.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/statefulset.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-use-udp
 lint-use-udp:
 	@echo "=> Linting examples/use-udp.yaml"
 	helm lint --strict -f examples/use-udp.yaml
 	@echo "=> Validating examples/use-udp.yaml"
-	helm template -f examples/use-udp.yaml . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/use-udp.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: test
 test: test-daemonset test-statefulset test-use-udp test-default

--- a/fluentd/Makefile
+++ b/fluentd/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-daemonset
@@ -23,21 +23,21 @@ lint-daemonset:
 	@echo "=> Linting examples/daemonset.yaml"
 	helm lint --strict -f examples/daemonset.yaml
 	@echo "=> Validating examples/daemonset.yaml"
-	helm template -f examples/daemonset.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/daemonset.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-statefulset
 lint-statefulset:
 	@echo "=> Linting examples/statefulset.yaml"
 	helm lint --strict -f examples/statefulset.yaml
 	@echo "=> Validating examples/statefulset.yaml"
-	helm template -f examples/statefulset.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/statefulset.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: lint-use-udp
 lint-use-udp:
 	@echo "=> Linting examples/use-udp.yaml"
 	helm lint --strict -f examples/use-udp.yaml
 	@echo "=> Validating examples/use-udp.yaml"
-	helm template -f examples/use-udp.yaml . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template -f examples/use-udp.yaml . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 
 .PHONY: test
 test: test-daemonset test-statefulset test-use-udp test-default

--- a/gcp-credentials/Makefile
+++ b/gcp-credentials/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/gcp-credentials/Makefile
+++ b/gcp-credentials/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/kube-schedule-scaler/Makefile
+++ b/kube-schedule-scaler/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/kube-schedule-scaler/Makefile
+++ b/kube-schedule-scaler/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/mailcatcher/Makefile
+++ b/mailcatcher/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/mailcatcher/Makefile
+++ b/mailcatcher/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/newrelic-php-agent/Makefile
+++ b/newrelic-php-agent/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/newrelic-php-agent/Makefile
+++ b/newrelic-php-agent/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/php/Makefile
+++ b/php/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/php/Makefile
+++ b/php/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/postfix/Makefile
+++ b/postfix/Makefile
@@ -18,7 +18,7 @@ lint-daemonset:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-daemonset-mailcatcher
@@ -26,7 +26,7 @@ lint-daemonset-mailcatcher:
 	@echo "=> Linting default values.yaml"
 	helm lint $(mailcatcher) --strict
 	@echo "=> Validating default value.yaml"
-	helm template $(mailcatcher) . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template $(mailcatcher) . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-deployment
@@ -34,7 +34,7 @@ lint-deployment:
 	@echo "=> Linting default values.yaml"
 	helm lint --set deployment.enabled=true --set daemonset.enabled=false --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP --strict
 	@echo "=> Validating default value.yaml"
-	helm template --set deployment.enabled=true --set daemonset.enabled=false --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template --set deployment.enabled=true --set daemonset.enabled=false --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-deployment-mailcatcher
@@ -42,7 +42,7 @@ lint-deployment-mailcatcher:
 	@echo "=> Linting default values.yaml"
 	helm lint --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP --strict
 	@echo "=> Validating default value.yaml"
-	helm template --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/postfix/Makefile
+++ b/postfix/Makefile
@@ -18,7 +18,7 @@ lint-daemonset:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-daemonset-mailcatcher
@@ -26,7 +26,7 @@ lint-daemonset-mailcatcher:
 	@echo "=> Linting default values.yaml"
 	helm lint $(mailcatcher) --strict
 	@echo "=> Validating default value.yaml"
-	helm template $(mailcatcher) . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template $(mailcatcher) . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-deployment
@@ -34,7 +34,7 @@ lint-deployment:
 	@echo "=> Linting default values.yaml"
 	helm lint --set deployment.enabled=true --set daemonset.enabled=false --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP --strict
 	@echo "=> Validating default value.yaml"
-	helm template --set deployment.enabled=true --set daemonset.enabled=false --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template --set deployment.enabled=true --set daemonset.enabled=false --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: lint-deployment-mailcatcher
@@ -42,7 +42,7 @@ lint-deployment-mailcatcher:
 	@echo "=> Linting default values.yaml"
 	helm lint --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP --strict
 	@echo "=> Validating default value.yaml"
-	helm template --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template --set deployment.enabled=true --set daemonset.enabled=false $(mailcatcher) --set deployment.podDisruptionBudget.enabled=true --set deployment.service.type=ClusterIP . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/raw/Makefile
+++ b/raw/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/raw/Makefile
+++ b/raw/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/regcred/Makefile
+++ b/regcred/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/regcred/Makefile
+++ b/regcred/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/slime/Makefile
+++ b/slime/Makefile
@@ -47,7 +47,7 @@ lint-default:
 		--set 'deployment.enabled=true' \
 		--set 'deployment.pod.container[0].image=k8s.gcr.io/pause:latest' \
 		--set 'deployment.pod.container[0].name=pause' \
-		 . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+		 . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/slime/Makefile
+++ b/slime/Makefile
@@ -47,7 +47,7 @@ lint-default:
 		--set 'deployment.enabled=true' \
 		--set 'deployment.pod.container[0].image=k8s.gcr.io/pause:latest' \
 		--set 'deployment.pod.container[0].name=pause' \
-		 . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+		 . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/twistlock-console/Makefile
+++ b/twistlock-console/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/twistlock-console/Makefile
+++ b/twistlock-console/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/twistlock-defender/Makefile
+++ b/twistlock-defender/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test

--- a/twistlock-defender/Makefile
+++ b/twistlock-defender/Makefile
@@ -15,7 +15,7 @@ lint-default:
 	@echo "=> Linting default values.yaml"
 	helm lint --strict
 	@echo "=> Validating default value.yaml"
-	helm template . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
+	helm template . | kubeval --strict --ignore-missing-schemas --additional-schema-locations https://raw.githubusercontent.com/cw-ozaki/kubernetes-json-schema/master/ --kubernetes-version $(KUBERNETES_VERSION) --exit-on-error
 	@echo ""
 
 .PHONY: test


### PR DESCRIPTION
```
$ kubeval --help
Validate a Kubernetes YAML file against the relevant schema

Usage:
  kubeval <file> [file...] [flags]

Flags:
      --additional-schema-locations strings   Comma-seperated list of secondary base URLs used to download schemas
  -d, --directories strings                   A comma-separated list of directories to recursively search for YAML documents
      --exit-on-error                         Immediately stop execution when the first error is encountered
  -f, --filename string                       filename to be displayed when testing manifests read from stdin (default "stdin")
      --force-color                           Force colored output even if stdout is not a TTY
  -h, --help                                  help for kubeval
      --ignore-missing-schemas                Skip validation for resource definitions without a schema
  -i, --ignored-filename-patterns strings     A comma-separated list of regular expressions specifying filenames to ignore
      --insecure-skip-tls-verify              If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
  -v, --kubernetes-version string             Version of Kubernetes to validate against (default "master")
      --openshift                             Use OpenShift schemas instead of upstream Kubernetes
  -o, --output string                         The format of the output of this script. Options are: [stdout json tap]
      --quiet                                 Silences any output aside from the direct results
      --reject-kinds strings                  Comma-separated list of case-sensitive kinds to prohibit validating against schemas
  -s, --schema-location string                Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION.
      --skip-kinds strings                    Comma-separated list of case-sensitive kinds to skip when validating against schemas
      --strict                                Disallow additional properties not in schema
      --version                               version for kubeval
```

Enabled `--strict` in kubeval to detect the specification of properties that do not exist in the schema.

#### Checklist

- [x] Chart Version bumped


