### PR TITLE
[php] support ingress v1

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/templates/_helpers.tpl
+++ b/php/templates/_helpers.tpl
@@ -65,6 +65,8 @@ Create the name of the service account to use
 {{- define "php.ingress.apiVersion" -}}
 {{- if .Values.ingress.overrideApiVersion -}}
 {{ .Values.ingress.overrideApiVersion }}
+{{- else if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 networking.k8s.io/v1beta1
 {{- else -}}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -29,11 +29,24 @@ spec:
           {{- end }}
           - path: {{ .path }}
             backend:
+              {{- if semverCompare ">=1.19-0" $root.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "php.fullname" $root }}
+              {{- if $root.Values.nginx.enabled }}
+                port:
+                  number: {{ $root.Values.service.port | default $root.Values.nginx.containerPort }}
+              {{- else }}
+              service:
+                port:
+                  number: {{ $root.Values.service.port | default $root.Values.fpm.containerPort }}
+              {{- end }}
+              {{- else }}
               serviceName: {{ include "php.fullname" $root }}
               {{- if $root.Values.nginx.enabled }}
               servicePort: {{ $root.Values.service.port | default $root.Values.nginx.containerPort }}
               {{- else }}
               servicePort: {{ $root.Values.service.port | default $root.Values.fpm.containerPort }}
+              {{- end }}
               {{- end }}
     {{- end }}
 {{- end }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -36,7 +36,6 @@ spec:
                 port:
                   number: {{ $root.Values.service.port | default $root.Values.nginx.containerPort }}
               {{- else }}
-              service:
                 port:
                   number: {{ $root.Values.service.port | default $root.Values.fpm.containerPort }}
               {{- end }}


### PR DESCRIPTION
**support ingress v1 for kubernetes 1.19**

addressed the following changes
- `apiVersion`
- `backend.service`
  - https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules 
  - https://github.com/kubernetes/kubernetes/pull/89778
#### Checklist

- [x] Chart Version bumped


