### PR TITLE
[mysql] Fix helm test mysql

### DIFF
--- a/mysql/Chart.yaml
+++ b/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 1.6.9
+version: 1.6.10
 appVersion: 5.7.30
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/mysql/templates/tests/test.yaml
+++ b/mysql/templates/tests/test.yaml
@@ -33,15 +33,30 @@ spec:
   tolerations:
 {{ toYaml . | indent 4 }}
   {{- end }}
+  initContainers:
+  - name: {{ .Release.Name }}-test-framework
+    image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # copy bats to tools dir
+      cp -R /opt/bats /tools/bats
+    volumeMounts:
+    - mountPath: /tools
+      name: tools
+
   containers:
     - name: {{ .Release.Name }}-test
-      image: "{{ .Values.testFramework.image }}:{{ .Values.testFramework.tag }}"
-      imagePullPolicy: "{{ .Values.testFramework.imagePullPolicy}}"
-      command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
+      image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+      command: ["/tools/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests
         name: tests
         readOnly: true
+      - mountPath: /tools
+        name: tools
       {{- if .Values.ssl.enabled }}
       - name: certificates
         mountPath: /ssl
@@ -50,6 +65,8 @@ spec:
   - name: tests
     configMap:
       name: {{ template "mysql.fullname" . }}-test
+  - name: tools
+    emptyDir: {}
   {{- if .Values.ssl.enabled }}
   - name: certificates
     secret:


### PR DESCRIPTION
This [PR](https://github.com/helm/charts/pull/23075/files
) caused the test to fail when the root user password was specified. Since the test only runs when the root password is specified, the CI passed on helm/charts repo.

#### What I did

- Run the test in a container with MySQL client installed


#### Before

```
$ helm install mysql ./ --set mysqlRootPassword=secret

$ helm test mysql
NAME: mysql
LAST DEPLOYED: Fri Mar  5 18:26:31 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE:     mysql-test
Last Started:   Fri Mar  5 18:26:47 2021
Last Completed: Fri Mar  5 18:26:49 2021
Phase:          Failed
...

$ kubectl logs mysql-test
1..1
not ok 1 Testing MySQL Connection
# (in test file /tests/run.sh, line 2)
#   `mysql --host=mysql --port=3306 -u root -psecret' failed with status 127
# /tmp/bats-run-1/bats.29.src: line 2: mysql: command not found
```

#### After

```
$ helm test mysql
NAME: mysql
LAST DEPLOYED: Fri Mar  5 18:25:43 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE:     mysql-test
Last Started:   Fri Mar  5 18:25:53 2021
Last Completed: Fri Mar  5 18:25:55 2021
Phase:          Succeeded
...

```

#### Checklist

- [x] Chart Version bumped


