### PR TITLE
[PHP] add pathType param for ingress v1

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -28,6 +28,9 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           - path: {{ .path }}
+            {{- if semverCompare ">=1.19-0" $root.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $root.Capabilities.KubeVersion.GitVersion }}
               service:


### PR DESCRIPTION
- add pathType param for ingress v1

  - pathType has been required since v1
    - https://github.com/kubernetes/kubernetes/pull/89778   
    - > * `pathType` no longer has a default value in v1; "Exact", "Prefix", or "ImplementationSpecific" must be specified

  - value (`ImplementationSpecific`) is set to the same as the default value in 1.18(v1beta1). 
#### Checklist

- [x] Chart Version bumped


