### PR TITLE
[akka] add patyType param for Ingress v1

### DIFF
--- a/akka/Chart.yaml
+++ b/akka/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/akka/templates/ingress-http.yaml
+++ b/akka/templates/ingress-http.yaml
@@ -37,6 +37,9 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
               {{- if eq $apiVersion "networking.k8s.io/v1" }}
               service:


### PR DESCRIPTION
- add pathType param for ingress v1

  - pathType has been required since v1
    - https://github.com/kubernetes/kubernetes/pull/89778   
    - > * `pathType` no longer has a default value in v1; "Exact", "Prefix", or "ImplementationSpecific" must be specified

  - value (`ImplementationSpecific`) is set to the same as the default value in 1.18(v1beta1). 
  - 
#### Checklist

- [x] Chart Version bumped


