### PR TITLE
[twistlock-defender] support admission cert & key

### DIFF
--- a/twistlock-defender/Chart.yaml
+++ b/twistlock-defender/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: twistlock-defender
-version: "0.1.1"
+version: "0.2.0"
 appVersion: "20.09.365"
 description: Chart for Twistlock Defender
 home: https://www.twistlock.com/

--- a/twistlock-defender/README.md
+++ b/twistlock-defender/README.md
@@ -85,6 +85,8 @@ The following table lists the configurable parameters of the gaurd chart and the
 |  `secret.client_cert` | client cert for defender | `"CLIENT_CERT"` |
 |  `secret.client_key` | client key for defender | `"CLIENT_KEY"` |
 |  `secret.service_parameter` | service parameter which genrated by console for defender | `"SERVICE_PARAMETER"` |
+|  `secret.admission_cert` | admission cert for defender | `nil` |
+|  `secret.admission_key` | admission key for defender | `nil` |
 |  `useHostNetwork` | Pod using hostNetwork | `true`|
 |  `useHostPID` | Pod using hostPID | `true`|
 |  `annotations` | Damonset annotations | `"{}"`|

--- a/twistlock-defender/templates/secret.yaml
+++ b/twistlock-defender/templates/secret.yaml
@@ -11,3 +11,9 @@ data:
   ca.pem: {{ .Values.secret.ca_cert }}
   client-cert.pem: {{ .Values.secret.client_cert }}
   client-key.pem: {{ .Values.secret.client_key }}
+  {{- with .Values.secret.admission_cert }}
+  admission-cert.pem: {{ . }}
+  {{- end }}
+  {{- with .Values.secret.admission_key }}
+  admission-key.pem: {{ . }}
+  {{- end }}

--- a/twistlock-defender/values.yaml
+++ b/twistlock-defender/values.yaml
@@ -80,6 +80,8 @@ secret:
   client_cert: "CLIENT_CERT"
   client_key: "CLIENT_KEY"
   service_parameter: "SERVICE_PARAMETER"
+  admission_cert:
+  admission_key:
 
 useHostNetwork: true
 useHostPID: true


### PR DESCRIPTION
In the manifest output by `twistcli`, admission cert and key were found in `Secrets`, so I supported them.

#### Checklist

- [X] Chart Version bumped


