### PR TITLE
ReplicaSet を残す数を設定できるようにする

### DIFF
--- a/akka/Chart.yaml
+++ b/akka/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/akka/README.md
+++ b/akka/README.md
@@ -130,6 +130,7 @@ The following table lists the configurable parameters of the akka chart and thei
 | `readinessProbe.successThreshold` | Minimum number of consecutive successes for a probe to be considered successful after a probe has failed | `1` |
 | `readinessProbe.failureThreshold` | Minimum number of consecutive successes for the probe to be considered successful after having failed | `3` |
 | `replicaCount` | Number of replicas | `3` |
+| `revisionHistoryLimit` | The number of old ReplicaSets to retain to allow rollback. | `10` |
 | `resources` | Pod resource requests & limits | `{}` |
 | `restartPolicy` | Container restart policy | `"Always"` |
 | `securityContext` | Allows you to overwrite the default securityContext applied to the container | `{}` |
@@ -430,4 +431,3 @@ NOTE: `-XX` is supported by a docker image create with sbt-native-packager. If t
 ## CPU
 
 Akka recommends that you specify [only resource.request](https://doc.akka.io/docs/akka/current/additional/deploying.html#deploying-to-kubernetes).
-

--- a/akka/templates/deployment.yaml
+++ b/akka/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       {{- include "akka.selectorLabels" . | nindent 6 }}
   strategy:
     {{- toYaml .Values.strategy | nindent 4 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
       annotations:

--- a/akka/values.yaml
+++ b/akka/values.yaml
@@ -223,6 +223,8 @@ readinessProbe:
 
 replicaCount: 3
 
+revisionHistoryLimit: 10
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### Why
- akka charts に`revisionHistoryLimit`(ReplicaSet を残す最大数)を設定できるようにする

#### What
- `revisionHistoryLimit`を設定できるように
  - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#deployment-v1-apps

#### Checklist
- [x] Chart Version bumped