### PR TITLE
fix svc for daemonset

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 3.6.3
 description: Postfix Helm Chart
 name: postfix
-version: 0.10.0
+version: 0.10.1

--- a/postfix/templates/_helpers.tpl
+++ b/postfix/templates/_helpers.tpl
@@ -75,3 +75,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return true if we can enable Service Internal Traffic Policy
+*/}}
+{{- define "enable-service-internal-traffic-policy" -}}
+{{- if and (semverCompare "^1.22-0" .Capabilities.KubeVersion.GitVersion) .Values.daemonset.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/postfix/templates/service.yaml
+++ b/postfix/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if or .Values.deployment.enabled .Values.statefulSet.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,4 +18,6 @@ spec:
       name: smtp
   selector:
     {{- include "postfix.selectorLabels" . | nindent 4 }}
+{{- if eq (include "enable-service-internal-traffic-policy" .) "true" }}
+  internalTrafficPolicy: Local
 {{- end }}


### PR DESCRIPTION
- fix service template for daemonset
  - FYI: https://github.com/DataDog/helm-charts/commit/920dd74aa847085c62dd4521613cdce0b52adc44

With `internalTrafficPolicy: Local`, it is possible to use postfix-daemonset on the same node via service, so we do not need to set `hostNetwork` to true for postfix-daemonset.

#### Checklist

- [x] Chart Version bumped


