### PR TITLE
Update autoscaling v2 condition

### DIFF
--- a/akka/Chart.yaml
+++ b/akka/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/akka/templates/autoscaling.yaml
+++ b/akka/templates/autoscaling.yaml
@@ -1,6 +1,6 @@
 {{- $root := . -}}
 {{- if .Values.autoscaling.enabled -}}
-{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v2beta2

--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.3
+version: 1.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/templates/autoscaling.yaml
+++ b/php/templates/autoscaling.yaml
@@ -1,6 +1,6 @@
 {{- $root := . -}}
 {{- if .Values.autoscaling.enabled -}}
-{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v2beta2


### PR DESCRIPTION
- change autoscaling v2 condition
  - Fixed because `.Capabilities.KubeVersion.GitVersion` is easier to use than `.Capabilities.APIVersions.Has`.

#### Checklist

- [x] Chart Version bumped