### PR TITLE
[php] fixes default values

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.4
+version: 1.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/README.md
+++ b/php/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the PHP chart and their
 | `autoscaling.labels` | Annotations for the horizonal pod autoscaler | `{}` |
 | `autoscaling.minReplicas` | Min pods for horizontal pod autoscaler | `nil` |
 | `autoscaling.maxReplicas` | Max pods for Horizontal pod autoscaler | `nil` |
-| `autoscaling.metrics` | Metrics used for autoscaling | `{}` |
+| `autoscaling.metrics` | Metrics used for autoscaling | `[]` |
 | `autoscaling.behavior` | Behavior for HorizontalPodAutoscaler.  This feature is available since 1.18 | `{}` |
 | `rbac.create` | If true, create & use RBAC resources | `true` |
 | `podSecurityPolicy.create` |  | `false` |

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -80,7 +80,7 @@ autoscaling:
   labels: {}
   minReplicas:
   maxReplicas:
-  metrics: {}
+  metrics: []
   #  - type: Resource
   #    resource:
   #      name: cpu
@@ -252,9 +252,12 @@ nginx:
 
   # `nginx.extraEnv` is additional environment variables.
   extraEnv: []
-  #  KEY1: VALUE1
-  #  KEY2: VALUE2
-  #  KEY3: VALUE3
+  #- name: key1
+  #  value: value1
+  #- name: HOST_IP
+  #  valueFrom:
+  #    fieldRef:
+  #      fieldPath: status.hostIP
 
   # `nginx.extraEnvFrom` is addtional envFrom.
   # Specify ConfigMap created in `nginx.templates` or Secret created in `nginx.secrets`.
@@ -358,7 +361,6 @@ fpm:
 
   # custom command for php-fpm image execution
   command: []
-  # command:
   # - php-fpm
   # - -d zend_extension=xdebug.so
 


### PR DESCRIPTION
A warning occurs when autoscaling is set.

```
coalesce.go:220: warning: cannot overwrite table with non table for php.autoscaling.metrics (map[])
```

This warning occurred because I set a value that did not match the type in `values.yaml`.

#### Checklist

- [X] Chart Version bumped


