### PR TITLE
[postfix]fix internalTrafficPolicy condition and comment out hostPort in values.yaml

### DIFF
--- a/postfix/Chart.yaml
+++ b/postfix/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postfix
-version: 0.10.3
+version: 0.11.0
 appVersion: "3.6.3"
 description: Postfix Helm Chart
 type: application

--- a/postfix/templates/_helpers.tpl
+++ b/postfix/templates/_helpers.tpl
@@ -75,14 +75,3 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return true if we can enable Service Internal Traffic Policy
-*/}}
-{{- define "enable-service-internal-traffic-policy" -}}
-{{- if and (semverCompare "^1.22-0" .Capabilities.KubeVersion.GitVersion) .Values.daemonset.enabled -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end -}}

--- a/postfix/templates/service.yaml
+++ b/postfix/templates/service.yaml
@@ -18,6 +18,8 @@ spec:
       name: smtp
   selector:
     {{- include "postfix.selectorLabels" . | nindent 4 }}
-{{- if eq (include "enable-service-internal-traffic-policy" .) "true" }}
-  internalTrafficPolicy: Local
+{{- if and (semverCompare "^1.22-0" .Capabilities.KubeVersion.GitVersion) .Values.daemonset.enabled -}}
+  {{- with .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/postfix/templates/service.yaml
+++ b/postfix/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
       name: smtp
   selector:
     {{- include "postfix.selectorLabels" . | nindent 4 }}
-{{- if and (semverCompare "^1.22-0" .Capabilities.KubeVersion.GitVersion) .Values.daemonset.enabled -}}
+{{- if and (semverCompare "^1.22-0" .Capabilities.KubeVersion.GitVersion) .Values.daemonset.enabled }}
   {{- with .Values.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ . }}
   {{- end }}

--- a/postfix/values.yaml
+++ b/postfix/values.yaml
@@ -58,7 +58,7 @@ daemonset:
   # If you set it to true, Daemonset use hostNetwork
   useHostNetwork: false
 
-  hostPort: 25
+  #hostPort: 25
 
   lifecycle:
     preStop:
@@ -115,6 +115,7 @@ service:
   type: ClusterIP
   port: 25
   annotations: {}
+  #internalTrafficPolicy: Local
 
 postfix:
   templates:


### PR DESCRIPTION
- fix internalTrafficPolicy condition
  - not to enforce it just because of daemonset.
- comment out `hostPort`

#### Checklist

- [x] Chart Version bumped


