### PR TITLE
Fixed slime cronJob initContainers.

### DIFF
--- a/slime/Chart.yaml
+++ b/slime/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1

--- a/slime/examples/cronjob-advanced.yaml
+++ b/slime/examples/cronjob-advanced.yaml
@@ -29,6 +29,13 @@ cronJob:
         volumeMounts:
           - name: configs
             mountPath: /configs
+    initContainers:
+      enabled: true
+      containers:
+        - name: init
+          image:
+            repository: busybox
+            tag: latest
     volumes:
       - name: configs
         configMap:

--- a/slime/templates/cronjob.yaml
+++ b/slime/templates/cronjob.yaml
@@ -191,7 +191,7 @@ spec:
           imagePullSecrets:
             {{- tpl (. | toYaml) $root | nindent 12 }}
           {{- end }}
-          {{- with .Values.cronJob.jobTemplate.initContainers.enabled }}
+          {{- with .Values.cronJob.jobTemplate.initContainers }}
           initContainers:
           {{- range $container := . }}
             - name: {{ include "slime.fullname" $root }}-{{ $container.name }}

--- a/slime/templates/cronjob.yaml
+++ b/slime/templates/cronjob.yaml
@@ -191,9 +191,9 @@ spec:
           imagePullSecrets:
             {{- tpl (. | toYaml) $root | nindent 12 }}
           {{- end }}
-          {{- if .Values.cronJob.jobTemplate.initContainers.enabled }}
+          {{- with .Values.cronJob.jobTemplate.initContainers.enabled }}
           initContainers:
-          {{- range $container := .Values.cronJob.jobTemplate.initContainers.containers }}
+          {{- range $container := . }}
             - name: {{ include "slime.fullname" $root }}-{{ $container.name }}
               image: {{ $container.image.repository }}:{{ $container.image.tag }}
               {{- with $container.image.pullPolicy }}

--- a/slime/templates/cronjob.yaml
+++ b/slime/templates/cronjob.yaml
@@ -191,7 +191,7 @@ spec:
           imagePullSecrets:
             {{- tpl (. | toYaml) $root | nindent 12 }}
           {{- end }}
-          {{- if .Values.initContainers.enabled }}
+          {{- if .Values.cronJob.jobTemplate.initContainers.enabled }}
           initContainers:
           {{- range $container := .Values.cronJob.jobTemplate.initContainers.containers }}
             - name: {{ include "slime.fullname" $root }}-{{ $container.name }}

--- a/slime/templates/cronjob.yaml
+++ b/slime/templates/cronjob.yaml
@@ -191,9 +191,9 @@ spec:
           imagePullSecrets:
             {{- tpl (. | toYaml) $root | nindent 12 }}
           {{- end }}
-          {{- with .Values.cronJob.jobTemplate.initContainers }}
+          {{- if .Values.cronJob.jobTemplate.initContainers.enabled }}
           initContainers:
-          {{- range $container := . }}
+          {{- range $container := .Values.cronJob.jobTemplate.initContainers.containers }}
             - name: {{ include "slime.fullname" $root }}-{{ $container.name }}
               image: {{ $container.image.repository }}:{{ $container.image.tag }}
               {{- with $container.image.pullPolicy }}

--- a/slime/values.yaml
+++ b/slime/values.yaml
@@ -254,18 +254,40 @@ cronJob:
   successfulJobsHistoryLimit: 3
   suspend: "false"
   #timeZone: "Etc/UTC"
-  jobTemplate: {}
-  #  activeDeadlineSeconds: 60
-  #  backoffLimit: 60
-  #  parallelism: 60
-  #  ttlSecondsAfterFinished: 60
-  #  containers:
-  #  - name: job-app
-  #    image:
-  #      repository: hello-world
-  #      tag: latest
-  #      pullPolicy: IfNotPresent
-  #      command: ["/hello"]
-  #      env: []
-  #      envFrom: []
-  #  restartPolicy: "OnFailure"
+  jobTemplate:
+    #  activeDeadlineSeconds: 60
+    #  backoffLimit: 60
+    #  parallelism: 60
+    #  ttlSecondsAfterFinished: 60
+    containers: [] # application containers
+    #  - name: job-app
+    #    image:
+    #      repository: hello-world
+    #      tag: latest
+    #      pullPolicy: IfNotPresent
+    #      command: ["/hello"]
+    #      env: []
+    #      envFrom: []
+    #  restartPolicy: "OnFailure"
+    initContainers:
+      enabled: false
+      containers: []
+      #  - name: init
+      #
+      #    image:
+      #      repository: chatwork/init
+      #      tag: latest
+      #
+      #    command: []
+      #    args: []
+      #
+      #    env: []
+      #    # - name: DEMO_GREETING
+      #    #   value: "Hello from the environment"
+      #
+      #    envFrom: []
+      #    # - configMapRef:
+      #    #     name: special-config
+      #    volumeMounts: []
+      #    # - name: volume-name
+      #    #   mountPath: /path/to


### PR DESCRIPTION
The initContainers key used to be the same as the deployment key, so it is now separated.

#### Checklist

- [x] Chart Version bumped

- [x] initContainers enabled.

```
$ kubectl -n chatwork get pod
NAME                            READY   STATUS      RESTARTS   AGE
slime-advanced-28202505-7t26j   0/1     Completed   0          4m9s
slime-advanced-28202506-vnkrr   0/1     Completed   0          3m9s
slime-advanced-28202507-zsvzc   0/1     Completed   0          2m9s
slime-advanced-28202508-ljr4j   0/1     Completed   0          69s
slime-advanced-28202509-fpt4g   0/1     Completed   0          9s


$  kubectl -n chatwork logs  slime-advanced-28202502-ld6jt
Defaulted container "slime-advanced-job" out of: slime-advanced-job, slime-advanced-init (init)

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (arm64v8)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/
```

