### PR TITLE
Support extra cronjob volumes.

### DIFF
--- a/slime/Chart.yaml
+++ b/slime/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.3.0

--- a/slime/README.md
+++ b/slime/README.md
@@ -47,68 +47,68 @@ Use each charts as needed or use them together.
 
 The following table lists the configurable parameters of the slime chart and their default values.
 
-| Parameter                             | Description                                                                                                                                        | Default       |
-|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `nameOverride`                        | Override name of app                                                                                                                               | `null`        |
-| `fullnameOverride`                    | Override the full qualified app name                                                                                                               | `null`        |
-| `deployment.enabled`                  | Enable deployment                                                                                                                                  | `false`       |
-| `strategy`                            | rolling update strategy for deployment                                                                                                             | `{}`          |
-| `annotations`                         | annotations for  deployment                                                                                                                        | `{}`          |
-| `labels`                              | labels for  deployment                                                                                                                             | `{}`          |
-| `replicas`                            | replicas for deployment                                                                                                                            | `1`           |
-| `revisionHistoryLimit`                | revisionHistoryLimit                                                                                                                               | `""`          |
-| `podAnnotations`                      | pod annotations                                                                                                                                    | `{}`          |
-| `podLabels`                           | pod labels                                                                                                                                         | `{}`          |
-| `podSecurityContext`                  | pod securityContext                                                                                                                                | `{}`          |
-| `affinity`                            | affinity                                                                                                                                           | `{}`          |
-| `nodeSelector`                        | nodeSelector                                                                                                                                       | `{}`          |
-| `imagePullSecrets`                    | imagePullSecrets                                                                                                                                   | `[]`          |
-| `readinessGates`                      | readinessGates                                                                                                                                     | `[]`          |
-| `priorityClassName`                   | priorityClassName                                                                                                                                  | `""`          |
-| `progressDeadlineSeconds`             | progressDeadlineSeconds                                                                                                                            | `""`          |
-| `volumes`                             | pod volumes(initContainers, containers)                                                                                                            | `[]`          |
-| `containers`                          | application containers                                                                                                                             | `[]`          |
-| `initContainers.enabled`              | if true, you can use initContainers                                                                                                                | `false`       |
-| `initContainers.containers`           | initContainers config                                                                                                                              | `[]`          |
-| `configmaps`                          | transform ConfigMap manifest. You can set `binaryData`, `data`                                                                                     | `{}`          |
-| `secrets`                             | transform Secret's manifest. You can set `data`, `stringData` and `type`                                                                           | `{}`          |
-| `autoscaling.enabled`                 | if true, you can use hpa                                                                                                                           | `false`       |
-| `autoscaling.behavior`                | autscaling behavior https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior                       | `{}`          |
-| `autoscaling.metrics`                 | autoscaling metrics                                                                                                                                | `[]`          |
-| `autoscaling.maxReplicas`             | autoscaling maxReplicas                                                                                                                            | `2`           |
-| `autoscaling.minReplicas`             | autoscaling minReplicas                                                                                                                            | `1`           |
-| `service.enabled`                     | if true, you can use service                                                                                                                       | `false`       |
-| `service.type`                        | service type(ClusterIP, NodePort, LoadBalancer)                                                                                                    | `"ClusterIP"` |
-| `service.ports`                       | service ports                                                                                                                                      | `{}`          |
-| `clusterRole.enabled`                 | if true, you can use clusterRole                                                                                                                   | `false`       |
-| `clusterRole.rules`                   | clusterRole rules                                                                                                                                  | `[]`          |
-| `role.enabled`                        | if true, you can use role                                                                                                                          | `false`       |
-| `role.rules`                          | role rules                                                                                                                                         | `[]`          |
-| `serviceAccount.create`               | if true, you can create serviceAccount                                                                                                             | `false`       |
-| `serviceAccount.name`                 | if you create serviceAccount, you can set name                                                                                                     | `null`        |
-| `serviceAccount.labels`               | service account labels                                                                                                                             | `{}`          |
-| `serviceAccount.annotations`          | serviceAccount annotations                                                                                                                         | `{}`          |
-| `podDisruptionBudget.enabled`         | if ture, you can use podDisruptionBudget                                                                                                           | `false`       |
-| `podDisruptionBudget.annotations`     | podDisruptionBudget annotations                                                                                                                    | `{}`          |
-| `podDisruptionBudget.labels`          | podDisruptionBudget labels                                                                                                                         | `{}`          |
-| `podDisruptionBudget.maxUnavailable`  | podDisruptionBudget maxUnavailable                                                                                                                 | `null`        |
-| `podDisruptionBudget.minAvailable`    | podDisruptionBudget minAvailable                                                                                                                   | `null`        |
-| `ingress.enabled`                     | if true, you can use ingress                                                                                                                       | `false`       |
-| `ingress.ingresses`                   | ingresses config                                                                                                                                   | `{}`          |
-| `cronJob.enabled`                     | if true, you can use CronJob                                                                                                                       | `false`       |
-| `schedule`                            | CronJob's schedule                                                                                                                                 | `""`          |
-| `cronJobRestartPolicy`                | CronJob's restartPolicy                                                                                                                            | `OnFailure`   |
-| `concurrencyPolicy`                   | CronJob's concurrencyPolicy                                                                                                                        | `Allow`       |
-| `failedJobsHistoryLimit`              | CronJob's failedJobsHistoryLimit                                                                                                                   | `1`           |
-| `startingDeadlineSeconds`             | CronJob's startingDeadlineSeconds                                                                                                                  | `null`        |
-| `successfulJobsHistoryLimit`          | CronJob's successfulJobsHistoryLimit                                                                                                               | `3`           |
-| `suspend`                             | CronJob's suspend                                                                                                                                  | `null`        |
-| `timeZone`                            | CronJob's timeZone https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#cronjob-v1-batch                                           | `null`        |
-| `cronJobContainers`                   | CronJob's containers https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#jobtemplatespec-v1-batch                                 | `[]`          |
-| `cronJobVolumes`                      | CronJob's pod volumes(initContainers, containers)                                                                                                  | `[]`          |
-| `additionalCronJobVolumes`            | CronJob's additional pod volumes(initContainers, containers). Use when you want to add volume other than the common settings for each application. | `[]`          |
-| `test.enabled`                        | if true, you can use helm test                                                                                                                     | `false`       |
-| `test.containers`                     | helm test container config                                                                                                                         | `[]`          |
+| Parameter                            | Description                                                                                                                                        | Default       |
+|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `nameOverride`                       | Override name of app                                                                                                                               | `null`        |
+| `fullnameOverride`                   | Override the full qualified app name                                                                                                               | `null`        |
+| `deployment.enabled`                 | Enable deployment                                                                                                                                  | `false`       |
+| `strategy`                           | rolling update strategy for deployment                                                                                                             | `{}`          |
+| `annotations`                        | annotations for  deployment                                                                                                                        | `{}`          |
+| `labels`                             | labels for  deployment                                                                                                                             | `{}`          |
+| `replicas`                           | replicas for deployment                                                                                                                            | `1`           |
+| `revisionHistoryLimit`               | revisionHistoryLimit                                                                                                                               | `""`          |
+| `podAnnotations`                     | pod annotations                                                                                                                                    | `{}`          |
+| `podLabels`                          | pod labels                                                                                                                                         | `{}`          |
+| `podSecurityContext`                 | pod securityContext                                                                                                                                | `{}`          |
+| `affinity`                           | affinity                                                                                                                                           | `{}`          |
+| `nodeSelector`                       | nodeSelector                                                                                                                                       | `{}`          |
+| `imagePullSecrets`                   | imagePullSecrets                                                                                                                                   | `[]`          |
+| `readinessGates`                     | readinessGates                                                                                                                                     | `[]`          |
+| `priorityClassName`                  | priorityClassName                                                                                                                                  | `""`          |
+| `progressDeadlineSeconds`            | progressDeadlineSeconds                                                                                                                            | `""`          |
+| `volumes`                            | pod volumes(initContainers, containers)                                                                                                            | `[]`          |
+| `containers`                         | application containers                                                                                                                             | `[]`          |
+| `initContainers.enabled`             | if true, you can use initContainers                                                                                                                | `false`       |
+| `initContainers.containers`          | initContainers config                                                                                                                              | `[]`          |
+| `configmaps`                         | transform ConfigMap manifest. You can set `binaryData`, `data`                                                                                     | `{}`          |
+| `secrets`                            | transform Secret's manifest. You can set `data`, `stringData` and `type`                                                                           | `{}`          |
+| `autoscaling.enabled`                | if true, you can use hpa                                                                                                                           | `false`       |
+| `autoscaling.behavior`               | autscaling behavior https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior                       | `{}`          |
+| `autoscaling.metrics`                | autoscaling metrics                                                                                                                                | `[]`          |
+| `autoscaling.maxReplicas`            | autoscaling maxReplicas                                                                                                                            | `2`           |
+| `autoscaling.minReplicas`            | autoscaling minReplicas                                                                                                                            | `1`           |
+| `service.enabled`                    | if true, you can use service                                                                                                                       | `false`       |
+| `service.type`                       | service type(ClusterIP, NodePort, LoadBalancer)                                                                                                    | `"ClusterIP"` |
+| `service.ports`                      | service ports                                                                                                                                      | `{}`          |
+| `clusterRole.enabled`                | if true, you can use clusterRole                                                                                                                   | `false`       |
+| `clusterRole.rules`                  | clusterRole rules                                                                                                                                  | `[]`          |
+| `role.enabled`                       | if true, you can use role                                                                                                                          | `false`       |
+| `role.rules`                         | role rules                                                                                                                                         | `[]`          |
+| `serviceAccount.create`              | if true, you can create serviceAccount                                                                                                             | `false`       |
+| `serviceAccount.name`                | if you create serviceAccount, you can set name                                                                                                     | `null`        |
+| `serviceAccount.labels`              | service account labels                                                                                                                             | `{}`          |
+| `serviceAccount.annotations`         | serviceAccount annotations                                                                                                                         | `{}`          |
+| `podDisruptionBudget.enabled`        | if ture, you can use podDisruptionBudget                                                                                                           | `false`       |
+| `podDisruptionBudget.annotations`    | podDisruptionBudget annotations                                                                                                                    | `{}`          |
+| `podDisruptionBudget.labels`         | podDisruptionBudget labels                                                                                                                         | `{}`          |
+| `podDisruptionBudget.maxUnavailable` | podDisruptionBudget maxUnavailable                                                                                                                 | `null`        |
+| `podDisruptionBudget.minAvailable`   | podDisruptionBudget minAvailable                                                                                                                   | `null`        |
+| `ingress.enabled`                    | if true, you can use ingress                                                                                                                       | `false`       |
+| `ingress.ingresses`                  | ingresses config                                                                                                                                   | `{}`          |
+| `cronJob.enabled`                    | if true, you can use CronJob                                                                                                                       | `false`       |
+| `schedule`                           | CronJob's schedule                                                                                                                                 | `""`          |
+| `cronJobRestartPolicy`               | CronJob's restartPolicy                                                                                                                            | `OnFailure`   |
+| `concurrencyPolicy`                  | CronJob's concurrencyPolicy                                                                                                                        | `Allow`       |
+| `failedJobsHistoryLimit`             | CronJob's failedJobsHistoryLimit                                                                                                                   | `1`           |
+| `startingDeadlineSeconds`            | CronJob's startingDeadlineSeconds                                                                                                                  | `null`        |
+| `successfulJobsHistoryLimit`         | CronJob's successfulJobsHistoryLimit                                                                                                               | `3`           |
+| `suspend`                            | CronJob's suspend                                                                                                                                  | `null`        |
+| `timeZone`                           | CronJob's timeZone https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#cronjob-v1-batch                                           | `null`        |
+| `cronJobContainers`                  | CronJob's containers https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#jobtemplatespec-v1-batch                                 | `[]`          |
+| `cronJobVolumes`                     | CronJob's pod volumes(initContainers, containers)                                                                                                  | `[]`          |
+| `extraCronJobVolumes`                | CronJob's extra pod volumes(initContainers, containers). Use when you want to add volume other than the common settings for each application. | `[]`          |
+| `test.enabled`                       | if true, you can use helm test                                                                                                                     | `false`       |
+| `test.containers`                    | helm test container config                                                                                                                         | `[]`          |
 
 
 # generate README

--- a/slime/README.md
+++ b/slime/README.md
@@ -47,66 +47,68 @@ Use each charts as needed or use them together.
 
 The following table lists the configurable parameters of the slime chart and their default values.
 
-| Parameter                             | Description                                                                                                                  | Default       |
-|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `nameOverride`                        | Override name of app                                                                                                         | `null`        |
-| `fullnameOverride`                    | Override the full qualified app name                                                                                         | `null`        |
-| `deployment.enabled`                  | Enable deployment                                                                                                            | `false`       |
-| `strategy`                            | rolling update strategy for deployment                                                                                       | `{}`          |
-| `annotations`                         | annotations for  deployment                                                                                                  | `{}`          |
-| `labels`                              | labels for  deployment                                                                                                       | `{}`          |
-| `replicas`                            | replicas for deployment                                                                                                      | `1`           |
-| `revisionHistoryLimit`                | revisionHistoryLimit                                                                                                         | `""`          |
-| `podAnnotations`                      | pod annotations                                                                                                              | `{}`          |
-| `podLabels`                           | pod labels                                                                                                                   | `{}`          |
-| `podSecurityContext`                  | pod securityContext                                                                                                          | `{}`          |
-| `affinity`                            | affinity                                                                                                                     | `{}`          |
-| `nodeSelector`                        | nodeSelector                                                                                                                 | `{}`          |
-| `imagePullSecrets`                    | imagePullSecrets                                                                                                             | `[]`          |
-| `readinessGates`                      | readinessGates                                                                                                               | `[]`          |
-| `priorityClassName`                   | priorityClassName                                                                                                            | `""`          |
-| `progressDeadlineSeconds`             | progressDeadlineSeconds                                                                                                      | `""`          |
-| `volumes`                             | pod volumes(initContainers, containers)                                                                                      | `[]`          |
-| `containers`                          | application containers                                                                                                       | `[]`          |
-| `initContainers.enabled`              | if true, you can use initContainers                                                                                          | `false`       |
-| `initContainers.containers`           | initContainers config                                                                                                        | `[]`          |
-| `configmaps`                          | transform ConfigMap manifest. You can set `binaryData`, `data`                                                               | `{}`          |
-| `secrets`                             | transform Secret's manifest. You can set `data`, `stringData` and `type`                                                     | `{}`          |
-| `autoscaling.enabled`                 | if true, you can use hpa                                                                                                     | `false`       |
-| `autoscaling.behavior`                | autscaling behavior https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior | `{}`          |
-| `autoscaling.metrics`                 | autoscaling metrics                                                                                                          | `[]`          |
-| `autoscaling.maxReplicas`             | autoscaling maxReplicas                                                                                                      | `2`           |
-| `autoscaling.minReplicas`             | autoscaling minReplicas                                                                                                      | `1`           |
-| `service.enabled`                     | if true, you can use service                                                                                                 | `false`       |
-| `service.type`                        | service type(ClusterIP, NodePort, LoadBalancer)                                                                              | `"ClusterIP"` |
-| `service.ports`                       | service ports                                                                                                                | `{}`          |
-| `clusterRole.enabled`                 | if true, you can use clusterRole                                                                                             | `false`       |
-| `clusterRole.rules`                   | clusterRole rules                                                                                                            | `[]`          |
-| `role.enabled`                        | if true, you can use role                                                                                                    | `false`       |
-| `role.rules`                          | role rules                                                                                                                   | `[]`          |
-| `serviceAccount.create`               | if true, you can create serviceAccount                                                                                       | `false`       |
-| `serviceAccount.name`                 | if you create serviceAccount, you can set name                                                                               | `null`        |
-| `serviceAccount.labels`               | service account labels                                                                                                       | `{}`          |
-| `serviceAccount.annotations`          | serviceAccount annotations                                                                                                   | `{}`          |
-| `podDisruptionBudget.enabled`         | if ture, you can use podDisruptionBudget                                                                                     | `false`       |
-| `podDisruptionBudget.annotations`     | podDisruptionBudget annotations                                                                                              | `{}`          |
-| `podDisruptionBudget.labels`          | podDisruptionBudget labels                                                                                                   | `{}`          |
-| `podDisruptionBudget.maxUnavailable`  | podDisruptionBudget maxUnavailable                                                                                           | `null`        |
-| `podDisruptionBudget.minAvailable`    | podDisruptionBudget minAvailable                                                                                             | `null`        |
-| `ingress.enabled`                     | if true, you can use ingress                                                                                                 | `false`       |
-| `ingress.ingresses`                   | ingresses config                                                                                                             | `{}`          |
-| `cronJob.enabled`                     | if true, you can use CronJob                                                                                                 | `false`       |
-| `schedule`                            | CronJob's schedule                                                                                                           | `""`          |
-| `cronJobRestartPolicy`                | CronJob's restartPolicy                                                                                                      | `OnFailure`   |
-| `concurrencyPolicy`                   | CronJob's concurrencyPolicy                                                                                                  | `Allow`       |
-| `failedJobsHistoryLimit`              | CronJob's failedJobsHistoryLimit                                                                                             | `1`           |
-| `startingDeadlineSeconds`             | CronJob's startingDeadlineSeconds                                                                                            | `null`        |
-| `successfulJobsHistoryLimit`          | CronJob's successfulJobsHistoryLimit                                                                                         | `3`           |
-| `suspend`                             | CronJob's suspend                                                                                                            | `null`        |
-| `timeZone`                            | CronJob's timeZone https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#cronjob-v1-batch                     | `null`        |
-| `cronJobContainers`                   | CronJob's containers https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#jobtemplatespec-v1-batch           | `[]`          |
-| `test.enabled`                        | if true, you can use helm test                                                                                               | `false`       |
-| `test.containers`                     | helm test container config                                                                                                   | `[]`          |
+| Parameter                             | Description                                                                                                                                        | Default       |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `nameOverride`                        | Override name of app                                                                                                                               | `null`        |
+| `fullnameOverride`                    | Override the full qualified app name                                                                                                               | `null`        |
+| `deployment.enabled`                  | Enable deployment                                                                                                                                  | `false`       |
+| `strategy`                            | rolling update strategy for deployment                                                                                                             | `{}`          |
+| `annotations`                         | annotations for  deployment                                                                                                                        | `{}`          |
+| `labels`                              | labels for  deployment                                                                                                                             | `{}`          |
+| `replicas`                            | replicas for deployment                                                                                                                            | `1`           |
+| `revisionHistoryLimit`                | revisionHistoryLimit                                                                                                                               | `""`          |
+| `podAnnotations`                      | pod annotations                                                                                                                                    | `{}`          |
+| `podLabels`                           | pod labels                                                                                                                                         | `{}`          |
+| `podSecurityContext`                  | pod securityContext                                                                                                                                | `{}`          |
+| `affinity`                            | affinity                                                                                                                                           | `{}`          |
+| `nodeSelector`                        | nodeSelector                                                                                                                                       | `{}`          |
+| `imagePullSecrets`                    | imagePullSecrets                                                                                                                                   | `[]`          |
+| `readinessGates`                      | readinessGates                                                                                                                                     | `[]`          |
+| `priorityClassName`                   | priorityClassName                                                                                                                                  | `""`          |
+| `progressDeadlineSeconds`             | progressDeadlineSeconds                                                                                                                            | `""`          |
+| `volumes`                             | pod volumes(initContainers, containers)                                                                                                            | `[]`          |
+| `containers`                          | application containers                                                                                                                             | `[]`          |
+| `initContainers.enabled`              | if true, you can use initContainers                                                                                                                | `false`       |
+| `initContainers.containers`           | initContainers config                                                                                                                              | `[]`          |
+| `configmaps`                          | transform ConfigMap manifest. You can set `binaryData`, `data`                                                                                     | `{}`          |
+| `secrets`                             | transform Secret's manifest. You can set `data`, `stringData` and `type`                                                                           | `{}`          |
+| `autoscaling.enabled`                 | if true, you can use hpa                                                                                                                           | `false`       |
+| `autoscaling.behavior`                | autscaling behavior https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior                       | `{}`          |
+| `autoscaling.metrics`                 | autoscaling metrics                                                                                                                                | `[]`          |
+| `autoscaling.maxReplicas`             | autoscaling maxReplicas                                                                                                                            | `2`           |
+| `autoscaling.minReplicas`             | autoscaling minReplicas                                                                                                                            | `1`           |
+| `service.enabled`                     | if true, you can use service                                                                                                                       | `false`       |
+| `service.type`                        | service type(ClusterIP, NodePort, LoadBalancer)                                                                                                    | `"ClusterIP"` |
+| `service.ports`                       | service ports                                                                                                                                      | `{}`          |
+| `clusterRole.enabled`                 | if true, you can use clusterRole                                                                                                                   | `false`       |
+| `clusterRole.rules`                   | clusterRole rules                                                                                                                                  | `[]`          |
+| `role.enabled`                        | if true, you can use role                                                                                                                          | `false`       |
+| `role.rules`                          | role rules                                                                                                                                         | `[]`          |
+| `serviceAccount.create`               | if true, you can create serviceAccount                                                                                                             | `false`       |
+| `serviceAccount.name`                 | if you create serviceAccount, you can set name                                                                                                     | `null`        |
+| `serviceAccount.labels`               | service account labels                                                                                                                             | `{}`          |
+| `serviceAccount.annotations`          | serviceAccount annotations                                                                                                                         | `{}`          |
+| `podDisruptionBudget.enabled`         | if ture, you can use podDisruptionBudget                                                                                                           | `false`       |
+| `podDisruptionBudget.annotations`     | podDisruptionBudget annotations                                                                                                                    | `{}`          |
+| `podDisruptionBudget.labels`          | podDisruptionBudget labels                                                                                                                         | `{}`          |
+| `podDisruptionBudget.maxUnavailable`  | podDisruptionBudget maxUnavailable                                                                                                                 | `null`        |
+| `podDisruptionBudget.minAvailable`    | podDisruptionBudget minAvailable                                                                                                                   | `null`        |
+| `ingress.enabled`                     | if true, you can use ingress                                                                                                                       | `false`       |
+| `ingress.ingresses`                   | ingresses config                                                                                                                                   | `{}`          |
+| `cronJob.enabled`                     | if true, you can use CronJob                                                                                                                       | `false`       |
+| `schedule`                            | CronJob's schedule                                                                                                                                 | `""`          |
+| `cronJobRestartPolicy`                | CronJob's restartPolicy                                                                                                                            | `OnFailure`   |
+| `concurrencyPolicy`                   | CronJob's concurrencyPolicy                                                                                                                        | `Allow`       |
+| `failedJobsHistoryLimit`              | CronJob's failedJobsHistoryLimit                                                                                                                   | `1`           |
+| `startingDeadlineSeconds`             | CronJob's startingDeadlineSeconds                                                                                                                  | `null`        |
+| `successfulJobsHistoryLimit`          | CronJob's successfulJobsHistoryLimit                                                                                                               | `3`           |
+| `suspend`                             | CronJob's suspend                                                                                                                                  | `null`        |
+| `timeZone`                            | CronJob's timeZone https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#cronjob-v1-batch                                           | `null`        |
+| `cronJobContainers`                   | CronJob's containers https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#jobtemplatespec-v1-batch                                 | `[]`          |
+| `cronJobVolumes`                      | CronJob's pod volumes(initContainers, containers)                                                                                                  | `[]`          |
+| `additionalCronJobVolumes`            | CronJob's additional pod volumes(initContainers, containers). Use when you want to add volume other than the common settings for each application. | `[]`          |
+| `test.enabled`                        | if true, you can use helm test                                                                                                                     | `false`       |
+| `test.containers`                     | helm test container config                                                                                                                         | `[]`          |
 
 
 # generate README

--- a/slime/examples/cronjob-additional-volumes.yaml
+++ b/slime/examples/cronjob-additional-volumes.yaml
@@ -1,0 +1,26 @@
+cronJob:
+  enabled: true
+
+schedule: "*/5 * * * *"
+restartPolicy: OnFailure
+
+cronJobContainers:
+  - name: job
+    image:
+      repository: hello-world
+      tag: latest
+    imagePullPolicy: IfNotPresent
+
+cronJobRestartPolicy: Never
+
+cronJobVolumes:
+  - name: configs
+    configMap:
+      name: "slime-config"
+      defaultMode: 0644
+
+additionalCronJobVolumes:
+  - name: additional-configs
+    configMap:
+      name: "slime-additional-config"
+      defaultMode: 0644

--- a/slime/examples/cronjob-extra-volumes.yaml
+++ b/slime/examples/cronjob-extra-volumes.yaml
@@ -19,8 +19,8 @@ cronJobVolumes:
       name: "slime-config"
       defaultMode: 0644
 
-additionalCronJobVolumes:
-  - name: additional-configs
+extraCronJobVolumes:
+  - name: extra-configs
     configMap:
-      name: "slime-additional-config"
+      name: "slime-extra-config"
       defaultMode: 0644

--- a/slime/templates/cronjob.yaml
+++ b/slime/templates/cronjob.yaml
@@ -280,12 +280,12 @@ spec:
                   {{- include "slime.selectorLabels" $root | nindent 18 }}
             {{- end }}
           {{- end }}
-          {{- if or (.Values.cronJobVolumes) (.Values.additionalCronJobVolumes) }}
+          {{- if or (.Values.cronJobVolumes) (.Values.extraCronJobVolumes) }}
           volumes:
             {{- with .Values.cronJobVolumes }}
             {{- tpl (. | toYaml) $root | nindent 12 }}
             {{- end }}
-            {{- with .Values.additionalCronJobVolumes }}
+            {{- with .Values.extraCronJobVolumes }}
             {{- tpl (. | toYaml) $root | nindent 12 }}
             {{- end }}
           {{- end }}

--- a/slime/templates/cronjob.yaml
+++ b/slime/templates/cronjob.yaml
@@ -280,8 +280,13 @@ spec:
                   {{- include "slime.selectorLabels" $root | nindent 18 }}
             {{- end }}
           {{- end }}
-          {{- with .Values.cronJobVolumes }}
+          {{- if or (.Values.cronJobVolumes) (.Values.additionalCronJobVolumes) }}
           volumes:
+            {{- with .Values.cronJobVolumes }}
             {{- tpl (. | toYaml) $root | nindent 12 }}
+            {{- end }}
+            {{- with .Values.additionalCronJobVolumes }}
+            {{- tpl (. | toYaml) $root | nindent 12 }}
+            {{- end }}
           {{- end }}
 {{- end }}

--- a/slime/values.yaml
+++ b/slime/values.yaml
@@ -288,7 +288,7 @@ cronJobInitContainers:
 
 cronJobVolumes: [] # CronJob's pod volumes(initContainers, containers)
 
-additionalCronJobVolumes: [] # CronJob's pod additional volumes. Use when you want to add volume other than the common settings for each application. (initContainers, containers)
+extraCronJobVolumes: [] # CronJob's pod extra volumes. Use when you want to add volume other than the common settings for each application. (initContainers, containers)
 
 cronJobImagePullSecrets: [] # annotations for imagePullSecrets
 

--- a/slime/values.yaml
+++ b/slime/values.yaml
@@ -288,6 +288,8 @@ cronJobInitContainers:
 
 cronJobVolumes: [] # CronJob's pod volumes(initContainers, containers)
 
+additionalCronJobVolumes: [] # CronJob's pod additional volumes. Use when you want to add volume other than the common settings for each application. (initContainers, containers)
+
 cronJobImagePullSecrets: [] # annotations for imagePullSecrets
 
 cronJobAnnotations: {} # annotations for CronJob


### PR DESCRIPTION
#### Checklist

- [x] Chart Version bumped

- [x] Examples test  with cronJobVolumes and extraCronJobVolumes.

```
$ kubectl get cronjob cronjob-slime -o yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  annotations:
    meta.helm.sh/release-name: cronjob
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2023-11-09T07:31:34Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: cronjob
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: slime
    helm.sh/chart: slime-1.3.0
  name: cronjob-slime
  namespace: default
  resourceVersion: "8144359"
  uid: 7d8b0341-9aed-4b54-98ce-17d3ce2d1f0b
spec:
  concurrencyPolicy: Allow
  failedJobsHistoryLimit: 1
  jobTemplate:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: cronjob
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: slime
        helm.sh/chart: slime-1.3.0
    spec:
      template:
        metadata:
          creationTimestamp: null
          labels:
            app.kubernetes.io/instance: cronjob
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/name: slime
            helm.sh/chart: slime-1.3.0
        spec:
          containers:
          - image: hello-world:latest
            imagePullPolicy: Always
            name: cronjob-slime-job
            resources: {}
            terminationMessagePath: /dev/termination-log
            terminationMessagePolicy: File
          dnsPolicy: ClusterFirst
          restartPolicy: Never
          schedulerName: default-scheduler
          securityContext: {}
          serviceAccount: default
          serviceAccountName: default
          terminationGracePeriodSeconds: 30
          volumes:
          - configMap:
              defaultMode: 420
              name: slime-config
            name: configs
          - configMap:
              defaultMode: 420
              name: slime-extra-config
            name: extra-configs
  schedule: '*/5 * * * *'
  successfulJobsHistoryLimit: 3
  suspend: false
status: {}
```

- [x] Examples test  with cronJobVolumes.

```
$ kubectl get cronjob cronjob-slime -o yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  annotations:
    meta.helm.sh/release-name: cronjob
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2023-11-09T07:31:34Z"
  generation: 2
  labels:
    app.kubernetes.io/instance: cronjob
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: slime
    helm.sh/chart: slime-1.3.0
  name: cronjob-slime
  namespace: default
  resourceVersion: "8145690"
  uid: 7d8b0341-9aed-4b54-98ce-17d3ce2d1f0b
spec:
  concurrencyPolicy: Allow
  failedJobsHistoryLimit: 1
  jobTemplate:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: cronjob
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: slime
        helm.sh/chart: slime-1.3.0
    spec:
      template:
        metadata:
          creationTimestamp: null
          labels:
            app.kubernetes.io/instance: cronjob
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/name: slime
            helm.sh/chart: slime-1.3.0
        spec:
          containers:
          - image: hello-world:latest
            imagePullPolicy: Always
            name: cronjob-slime-job
            resources: {}
            terminationMessagePath: /dev/termination-log
            terminationMessagePolicy: File
          dnsPolicy: ClusterFirst
          restartPolicy: Never
          schedulerName: default-scheduler
          securityContext: {}
          serviceAccount: default
          serviceAccountName: default
          terminationGracePeriodSeconds: 30
          volumes:
          - configMap:
              defaultMode: 420
              name: slime-config
            name: configs
  schedule: '*/5 * * * *'
  successfulJobsHistoryLimit: 3
  suspend: false
status:
  lastScheduleTime: "2023-11-09T07:40:00Z"
  lastSuccessfulTime: "2023-11-09T07:40:05Z"
```

- [x] Examples test  with extraCronJobVolumes.

```
$ kubectl get cronjob cronjob-slime -o yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  annotations:
    meta.helm.sh/release-name: cronjob
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2023-11-09T07:31:34Z"
  generation: 3
  labels:
    app.kubernetes.io/instance: cronjob
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: slime
    helm.sh/chart: slime-1.3.0
  name: cronjob-slime
  namespace: default
  resourceVersion: "8146393"
  uid: 7d8b0341-9aed-4b54-98ce-17d3ce2d1f0b
spec:
  concurrencyPolicy: Allow
  failedJobsHistoryLimit: 1
  jobTemplate:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: cronjob
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: slime
        helm.sh/chart: slime-1.3.0
    spec:
      template:
        metadata:
          creationTimestamp: null
          labels:
            app.kubernetes.io/instance: cronjob
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/name: slime
            helm.sh/chart: slime-1.3.0
        spec:
          containers:
          - image: hello-world:latest
            imagePullPolicy: Always
            name: cronjob-slime-job
            resources: {}
            terminationMessagePath: /dev/termination-log
            terminationMessagePolicy: File
          dnsPolicy: ClusterFirst
          restartPolicy: Never
          schedulerName: default-scheduler
          securityContext: {}
          serviceAccount: default
          serviceAccountName: default
          terminationGracePeriodSeconds: 30
          volumes:
          - configMap:
              defaultMode: 420
              name: slime-extra-config
            name: extra-configs
  schedule: '*/5 * * * *'
  successfulJobsHistoryLimit: 3
  suspend: false
status:
  lastScheduleTime: "2023-11-09T07:40:00Z"
  lastSuccessfulTime: "2023-11-09T07:40:05Z"
```

- [x] Examples test no volumes.

```
$ kubectl get cronjob cronjob-slime -o yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  annotations:
    meta.helm.sh/release-name: cronjob
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2023-11-09T07:31:34Z"
  generation: 4
  labels:
    app.kubernetes.io/instance: cronjob
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: slime
    helm.sh/chart: slime-1.3.0
  name: cronjob-slime
  namespace: default
  resourceVersion: "8146571"
  uid: 7d8b0341-9aed-4b54-98ce-17d3ce2d1f0b
spec:
  concurrencyPolicy: Allow
  failedJobsHistoryLimit: 1
  jobTemplate:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: cronjob
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: slime
        helm.sh/chart: slime-1.3.0
    spec:
      template:
        metadata:
          creationTimestamp: null
          labels:
            app.kubernetes.io/instance: cronjob
            app.kubernetes.io/managed-by: Helm
            app.kubernetes.io/name: slime
            helm.sh/chart: slime-1.3.0
        spec:
          containers:
          - image: hello-world:latest
            imagePullPolicy: Always
            name: cronjob-slime-job
            resources: {}
            terminationMessagePath: /dev/termination-log
            terminationMessagePolicy: File
          dnsPolicy: ClusterFirst
          restartPolicy: Never
          schedulerName: default-scheduler
          securityContext: {}
          serviceAccount: default
          serviceAccountName: default
          terminationGracePeriodSeconds: 30
  schedule: '*/5 * * * *'
  successfulJobsHistoryLimit: 3
  suspend: false
status:
  lastScheduleTime: "2023-11-09T07:45:00Z"
  lastSuccessfulTime: "2023-11-09T07:45:07Z"
```