### PR TITLE
Updated ingress configuration and enabled multiple paths in ingress.yaml

### DIFF
--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.0
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/Chart.yaml
+++ b/php/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.9
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/php/templates/NOTES.txt
+++ b/php/templates/NOTES.txt
@@ -1,7 +1,10 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ .path }}
+  {{ $host := .host}}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "php.fullname" . }})

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -27,7 +27,8 @@ spec:
           {{- with .extraPathes }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          - path: {{ .path }}
+          {{- range .paths }}
+          - path: {{ . }}
             {{- if semverCompare ">=1.19-0" $root.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
@@ -50,5 +51,6 @@ spec:
               servicePort: {{ $root.Values.service.port | default $root.Values.fpm.containerPort }}
               {{- end }}
               {{- end }}
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/php/templates/ingress.yaml
+++ b/php/templates/ingress.yaml
@@ -27,7 +27,10 @@ spec:
           {{- with .extraPathes }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range .paths }}
+          {{- $paths := list }}
+          {{- with .path }}{{- $paths = append $paths . }}{{- end }}
+          {{- range .paths }}{{- $paths = append $paths . }}{{- end }}
+          {{- range $paths }}
           - path: {{ . }}
             {{- if semverCompare ">=1.19-0" $root.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -54,6 +54,8 @@ ingress:
   annotations: {}
   hosts: []
   # - host: localhost
+  #   # The "path" field is deprecated and will be removed in the next major release. Use "paths" instead.
+  #   path: /
   #   paths:
   #   - /foo
   #   - /bar

--- a/php/values.yaml
+++ b/php/values.yaml
@@ -54,7 +54,9 @@ ingress:
   annotations: {}
   hosts: []
   # - host: localhost
-  #   path: /
+  #   paths:
+  #   - /foo
+  #   - /bar
   #   extraPathes:
   #     path: /foo
   #     backend:


### PR DESCRIPTION
This Pull Request introduces enhancements to the ingress configuration, enabling support for multiple paths per host and updating corresponding settings across NOTES.txt, ingress.yaml, and values.yaml files.

I applied the following PATCH to check the operation.
```diff
$ git diff
diff --git a/php/values.yaml b/php/values.yaml
index 1cb8676..9c6bcd3 100644
--- a/php/values.yaml
+++ b/php/values.yaml
@@ -52,20 +52,20 @@ ingress:
   enabled: false
   labels: {}
   annotations: {}
-  hosts: []
-  # - host: localhost
-  #   paths:
-  #   - /foo
-  #   - /bar
+  hosts:
+  - host: localhost
+    paths:
+    - /foo
+    - /bar
   #   extraPathes:
   #     path: /foo
   #     backend:
   #       serviceName: foo-service
   #       servicePort: 80
-  tls: []
-  # - hosts:
-  #     - example.com
-  #       secretName: examplecret-tls
+  tls:
+  - hosts:
+    - example.com
+    secretName: examplecret-tls
   ingressClassName: ''
```
```console
$ helm install php ./php
NAME: php
LAST DEPLOYED: Thu Mar 28 10:23:33 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:

  https://localhost/foo
  https://localhost/bar
```
```console
$ helm template php ./php --show-only templates/ingress.yaml
---
# Source: php/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
  labels:
    helm.sh/chart: php-2.0.0
    app.kubernetes.io/name: php
    app.kubernetes.io/instance: php
    app.kubernetes.io/version: "7.4"
    app.kubernetes.io/managed-by: Helm
  name: php
spec:
  ingressClassName:
  tls:
    - hosts:
      - example.com
      secretName: examplecret-tls
  rules:
    - host: localhost
      http:
        paths:
          - path: /foo
            pathType: ImplementationSpecific
            backend:
              service:
                name: php
                port:
                  number: 80
          - path: /bar
            pathType: ImplementationSpecific
            backend:
              service:
                name: php
                port:
                  number: 80
```

#### Checklist

- [x] Chart Version bumped


