### PR TITLE
Fix ingress template newline

### DIFF
--- a/slime/Chart.yaml
+++ b/slime/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1

--- a/slime/templates/ingress.yaml
+++ b/slime/templates/ingress.yaml
@@ -46,5 +46,5 @@ spec:
                   number: {{ .portNumber }}
         {{- end }}
     {{- end }}
-{{- end }}
+{{ end }}
 {{- end }}


### PR DESCRIPTION
## Summary
Fix a whitespace-trimming issue in ingress template so the document separator is rendered on its own line.

## Testing
- helm template test slime/