### PR TITLE
Add annotations support to ScaledObject template

### DIFF
--- a/http-service/Chart.yaml
+++ b/http-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: http-service
 description: An opinionated Helm chart for language-agnostic HTTP services with sensible defaults
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/http-service/templates/scaled-object.yaml
+++ b/http-service/templates/scaled-object.yaml
@@ -1,4 +1,6 @@
 {{- if eq .Values.autoscaling.type "keda" }}
+{{- $keda := required "autoscaling.keda is required when type is keda" .Values.autoscaling.keda }}
+{{- $triggers := required "autoscaling.keda.triggers is required when type is keda" $keda.triggers }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -6,6 +8,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "http-service.labels" . | nindent 4 }}
+  {{- with $keda.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     {{- if .Values.rollout.enabled }}
@@ -16,8 +22,6 @@ spec:
     kind: Deployment
     {{- end }}
     name: {{ include "http-service.fullname" . }}
-  {{- $keda := required "autoscaling.keda is required when type is keda" .Values.autoscaling.keda }}
-  {{- $triggers := required "autoscaling.keda.triggers is required when type is keda" $keda.triggers }}
   minReplicaCount: {{ required "autoscaling.minReplicas is required" .Values.autoscaling.minReplicas }}
   maxReplicaCount: {{ required "autoscaling.maxReplicas is required" .Values.autoscaling.maxReplicas }}
   {{- with $keda.pollingInterval }}


### PR DESCRIPTION
## Summary
- Add `autoscaling.keda.annotations` support to ScaledObject metadata
- Move `$keda` and `$triggers` variable definitions before metadata block to fix scope issue

This enables setting annotations like `autoscaling.keda.sh/paused` and `autoscaling.keda.sh/paused-replicas` on ScaledObject resources, which is needed for runtime replica override via ArgoCD environment variables.

## Test plan
- [x] `helm template` with keda type and annotations renders correctly
- [x] `helm template` with keda type without annotations still works
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)